### PR TITLE
fix: ViewerPage起動時の状態保存バグ修正、ウィンドウ非表示起動対応

### DIFF
--- a/image-folder-viewer/src-tauri/capabilities/default.json
+++ b/image-folder-viewer/src-tauri/capabilities/default.json
@@ -16,6 +16,7 @@
     "core:window:allow-set-position",
     "core:window:allow-set-focus",
     "core:window:allow-set-always-on-top",
+    "core:window:allow-show",
     "opener:default",
     "dialog:default"
   ]

--- a/image-folder-viewer/src-tauri/tauri.conf.json
+++ b/image-folder-viewer/src-tauri/tauri.conf.json
@@ -17,7 +17,8 @@
         "height": 600,
         "minWidth": 200,
         "minHeight": 200,
-        "focus": true
+        "focus": true,
+        "visible": false
       }
     ],
     "security": {

--- a/image-folder-viewer/src/pages/IndexPage.tsx
+++ b/image-folder-viewer/src/pages/IndexPage.tsx
@@ -61,6 +61,13 @@ export function IndexPage() {
     }
   }, [initialized, isAutoOpening, currentProfile, navigate]);
 
+  // 初期化完了後にウィンドウを表示（起動時フリッカー対策）
+  useEffect(() => {
+    if (initialized && !isAutoOpening) {
+      getCurrentWindow().show();
+    }
+  }, [initialized, isAutoOpening]);
+
   // 状態復元: 前回ViewerPageだった場合は復元遷移
   useEffect(() => {
     if (!currentProfile || restoredRef.current) return;

--- a/image-folder-viewer/src/pages/StartupPage.tsx
+++ b/image-folder-viewer/src/pages/StartupPage.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import {
   useProfileStore,
   useRecentProfiles,
@@ -20,6 +21,8 @@ export function StartupPage() {
     error,
     clearError,
     currentProfile,
+    initialized,
+    isAutoOpening,
   } = useProfileStore();
 
   const recentProfiles = useRecentProfiles();
@@ -35,6 +38,13 @@ export function StartupPage() {
       navigate("/");
     }
   }, [currentProfile, navigate]);
+
+  // 初期化完了後にウィンドウを表示（起動時フリッカー対策）
+  useEffect(() => {
+    if (initialized && !isAutoOpening) {
+      getCurrentWindow().show();
+    }
+  }, [initialized, isAutoOpening]);
 
   // 履歴からプロファイルを開く
   const handleOpenRecent = async (path: string) => {

--- a/image-folder-viewer/src/pages/ViewerPage.tsx
+++ b/image-folder-viewer/src/pages/ViewerPage.tsx
@@ -54,9 +54,6 @@ export function ViewerPage() {
     y: number;
   } | null>(null);
 
-  // 初回読み込みスキップ用フラグ
-  const isInitialLoadRef = useRef(true);
-
   // ズーム用ref
   const mainRef = useRef<HTMLElement>(null);
   const isResizingProgrammaticallyRef = useRef(false);
@@ -282,14 +279,7 @@ export function ViewerPage() {
 
   // 画像表示・オプション変更時にビューア状態を保存
   useEffect(() => {
-    // 初回読み込み時（loadImages完了直後）はスキップ
-    if (isInitialLoadRef.current) {
-      if (totalImages > 0) {
-        isInitialLoadRef.current = false;
-      }
-      return;
-    }
-
+    if (totalImages <= 0) return;
     saveViewerState();
   }, [actualIndex, hFlipEnabled, shuffleEnabled, saveViewerState, totalImages]);
 


### PR DESCRIPTION
Closes #1

## Summary

- **バグ修正**: ViewerPage で最初の画像を表示した状態でアプリを終了すると、次回起動時に ViewerPage が復元されない問題を修正
- **機能追加**: 起動時フリッカー対策として、初期化完了まで ウィンドウを非表示にする対応（`visible: false`）
- **パーミッション追加**: `core:window:allow-show` を `capabilities/default.json` に追加

## 変更詳細

### バグ修正: ViewerPage の状態保存ロジック（`ViewerPage.tsx`）

`isInitialLoadRef` フラグによる初回スキップのため、ナビゲーションなしで終了した場合に `saveViewerState()` が一度も呼ばれず、`lastPage: "viewer"` がディスクに保存されなかった。

`totalImages > 0` になった時点（初回ロード完了時）で即座に `saveViewerState()` を呼ぶよう変更することで修正。

### 起動時フリッカー対策（`IndexPage.tsx`、`StartupPage.tsx`）

`tauri.conf.json` で `visible: false` を設定し、初期化完了後（`initialized && !isAutoOpening`）に `getCurrentWindow().show()` を呼ぶことで、起動時の白い画面フリッカーを防止。

## Test plan

- [ ] IndexPage からサムネイルをクリックして ViewerPage を開く
- [ ] 画像ナビゲーションを一切行わずにウィンドウを閉じる
- [ ] 再起動 → ViewerPage が表示されること（最初の画像が表示されること）を確認
- [ ] ViewerPage で次画像に移動してから終了 → 再起動 → その画像が表示されることを確認
- [ ] 起動時にウィンドウがフリッカーしないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)