### PR TITLE
feat: カードモーダルのエラーUI表示 (#4)

### DIFF
--- a/image-folder-viewer/src/components/cards/CardAddModal.tsx
+++ b/image-folder-viewer/src/components/cards/CardAddModal.tsx
@@ -1,7 +1,7 @@
 // カード追加モーダル
 
 import { useState, useEffect } from "react";
-import { FolderOpen, ImageIcon } from "lucide-react";
+import { FolderOpen, ImageIcon, AlertTriangle } from "lucide-react";
 import { Modal, Button } from "../common/Modal";
 import {
   selectFolder,
@@ -40,6 +40,9 @@ export const CardAddModal = ({ isOpen, onClose, onAdd }: CardAddModalProps) => {
   const [isSelectingFolder, setIsSelectingFolder] = useState(false);
   const [isLoadingThumbnail, setIsLoadingThumbnail] = useState(false);
 
+  // エラー状態
+  const [error, setError] = useState<string | null>(null);
+
   // モーダルを閉じる時にリセット
   useEffect(() => {
     if (!isOpen) {
@@ -48,6 +51,7 @@ export const CardAddModal = ({ isOpen, onClose, onAdd }: CardAddModalProps) => {
       setTitle("");
       setThumbnailPath(null);
       setThumbnailUrl(null);
+      setError(null);
     }
   }, [isOpen]);
 
@@ -79,6 +83,7 @@ export const CardAddModal = ({ isOpen, onClose, onAdd }: CardAddModalProps) => {
         console.error("サムネイル読み込みエラー:", e);
         if (!cancelled) {
           setThumbnailUrl(null);
+          setError(`サムネイルの読み込みに失敗しました: ${e}`);
         }
       })
       .finally(() => {
@@ -95,6 +100,7 @@ export const CardAddModal = ({ isOpen, onClose, onAdd }: CardAddModalProps) => {
   // フォルダ選択
   const handleSelectFolder = async () => {
     setIsSelectingFolder(true);
+    setError(null);
     try {
       const path = await selectFolder();
       if (path) {
@@ -112,7 +118,7 @@ export const CardAddModal = ({ isOpen, onClose, onAdd }: CardAddModalProps) => {
       }
     } catch (e) {
       console.error("フォルダ選択エラー:", e);
-      onClose();
+      setError(`フォルダの選択に失敗しました: ${e}`);
     } finally {
       setIsSelectingFolder(false);
     }
@@ -120,6 +126,7 @@ export const CardAddModal = ({ isOpen, onClose, onAdd }: CardAddModalProps) => {
 
   // サムネイル変更
   const handleChangeThumbnail = async () => {
+    setError(null);
     try {
       const path = await selectImageFile(folderPath);
       if (path) {
@@ -127,6 +134,7 @@ export const CardAddModal = ({ isOpen, onClose, onAdd }: CardAddModalProps) => {
       }
     } catch (e) {
       console.error("画像選択エラー:", e);
+      setError(`画像の選択に失敗しました: ${e}`);
     }
   };
 
@@ -146,12 +154,18 @@ export const CardAddModal = ({ isOpen, onClose, onAdd }: CardAddModalProps) => {
   if (phase === "folder") {
     return (
       <Modal isOpen={isOpen} onClose={onClose} title="新規カード作成" width="sm">
-        <div className="flex flex-col items-center justify-center py-8">
+        <div className="flex flex-col items-center justify-center py-8 gap-4">
+          {error && (
+            <div className="w-full flex items-start gap-2 p-3 bg-red-50 border border-red-200 rounded text-red-700 text-sm">
+              <AlertTriangle size={18} className="flex-shrink-0 mt-0.5" />
+              <span>{error}</span>
+            </div>
+          )}
           {isSelectingFolder ? (
             <div className="text-gray-500">フォルダを選択してください...</div>
           ) : (
             <>
-              <FolderOpen size={48} className="text-gray-300 mb-4" />
+              <FolderOpen size={48} className="text-gray-300" />
               <Button variant="primary" onClick={handleSelectFolder}>
                 フォルダを選択
               </Button>
@@ -185,6 +199,14 @@ export const CardAddModal = ({ isOpen, onClose, onAdd }: CardAddModalProps) => {
       }
     >
       <div className="space-y-4">
+        {/* エラーメッセージ */}
+        {error && (
+          <div className="flex items-start gap-2 p-3 bg-red-50 border border-red-200 rounded text-red-700 text-sm">
+            <AlertTriangle size={18} className="flex-shrink-0 mt-0.5" />
+            <span>{error}</span>
+          </div>
+        )}
+
         {/* フォルダパス */}
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-1">

--- a/image-folder-viewer/src/components/cards/CardEditModal.tsx
+++ b/image-folder-viewer/src/components/cards/CardEditModal.tsx
@@ -42,6 +42,9 @@ export const CardEditModal = ({
   // ローディング状態
   const [isLoadingThumbnail, setIsLoadingThumbnail] = useState(false);
 
+  // エラー状態
+  const [error, setError] = useState<string | null>(null);
+
   // カードが変わったらフォーム値をリセット
   useEffect(() => {
     if (card && isOpen) {
@@ -49,6 +52,7 @@ export const CardEditModal = ({
       setFolderPath(card.folderPath);
       setThumbnailPath(card.thumbnail);
       setIsFolderChanged(false);
+      setError(null);
     }
   }, [card, isOpen]);
 
@@ -73,6 +77,7 @@ export const CardEditModal = ({
         console.error("サムネイル読み込みエラー:", e);
         if (!cancelled) {
           setThumbnailUrl(null);
+          setError(`サムネイルの読み込みに失敗しました: ${e}`);
         }
       })
       .finally(() => {
@@ -88,6 +93,7 @@ export const CardEditModal = ({
 
   // フォルダ変更（エラー状態のカード用）
   const handleChangeFolder = async () => {
+    setError(null);
     try {
       const path = await selectFolder();
       if (path) {
@@ -100,11 +106,13 @@ export const CardEditModal = ({
       }
     } catch (e) {
       console.error("フォルダ選択エラー:", e);
+      setError(`フォルダの選択に失敗しました: ${e}`);
     }
   };
 
   // サムネイル変更
   const handleChangeThumbnail = async () => {
+    setError(null);
     try {
       const path = await selectImageFile(folderPath);
       if (path) {
@@ -112,6 +120,7 @@ export const CardEditModal = ({
       }
     } catch (e) {
       console.error("画像選択エラー:", e);
+      setError(`画像の選択に失敗しました: ${e}`);
     }
   };
 
@@ -161,6 +170,14 @@ export const CardEditModal = ({
       }
     >
       <div className="space-y-4">
+        {/* 操作エラーメッセージ */}
+        {error && (
+          <div className="flex items-start gap-2 p-3 bg-red-50 border border-red-200 rounded text-red-700 text-sm">
+            <AlertTriangle size={18} className="flex-shrink-0 mt-0.5" />
+            <span>{error}</span>
+          </div>
+        )}
+
         {/* エラー状態の警告 */}
         {!isValid && !isFolderChanged && (
           <div className="flex items-center gap-2 p-3 bg-red-50 border border-red-200 rounded text-red-700 text-sm">


### PR DESCRIPTION
## Summary
- `CardAddModal`: フォルダ選択フェーズ・情報入力フェーズの両方にエラーバナーを追加
- `CardEditModal`: フォルダ選択・サムネイル変更・サムネイル読み込みの各エラーをモーダル内に表示
- エラーは各操作開始時にクリアされ、モーダルを開き直した時もリセットされる

## Test plan
- [ ] CardAddModal: フォルダ選択中にエラーが発生した場合、モーダルが閉じずエラーメッセージが表示される
- [ ] CardAddModal: サムネイル読み込みに失敗した場合、情報入力フェーズでエラーが表示される
- [ ] CardEditModal: フォルダ選択失敗時にエラーメッセージが表示される
- [ ] CardEditModal: サムネイル変更失敗時にエラーメッセージが表示される
- [ ] 別の操作を行うとエラーメッセージがクリアされる

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)