### PR TITLE
feat: サブディレクトリを含めた画像検索フラグの追加 (#18)

### DIFF
--- a/image-folder-viewer/src-tauri/src/commands/images.rs
+++ b/image-folder-viewer/src-tauri/src/commands/images.rs
@@ -187,9 +187,54 @@ pub fn get_thumbnail(app: AppHandle, image_path: String, size: u32) -> Result<St
     Ok(result)
 }
 
+/// パスが画像ファイルかどうか判定
+fn is_image_file(path: &Path) -> bool {
+    if !path.is_file() {
+        return false;
+    }
+    if let Some(ext) = path.extension() {
+        let ext_lower = ext.to_string_lossy().to_lowercase();
+        return IMAGE_EXTENSIONS.contains(&ext_lower.as_str());
+    }
+    false
+}
+
+/// フォルダ内の画像ファイルパスを収集（再帰オプション付き、ファイル名順）
+fn collect_images(dir: &Path, recursive: bool) -> Result<Vec<PathBuf>, String> {
+    let mut result: Vec<PathBuf> = Vec::new();
+
+    let entries = fs::read_dir(dir)
+        .map_err(|e| format!("フォルダの読み込みに失敗しました: {}", e))?;
+
+    let mut dirs: Vec<PathBuf> = Vec::new();
+
+    for entry in entries.filter_map(|e| e.ok()) {
+        let path = entry.path();
+        if is_image_file(&path) {
+            result.push(path);
+        } else if recursive && path.is_dir() {
+            dirs.push(path);
+        }
+    }
+
+    // 現在のディレクトリの画像をファイル名順にソート
+    result.sort_by(|a, b| a.file_name().cmp(&b.file_name()));
+
+    // サブディレクトリを再帰的に処理（ディレクトリ名順）
+    if recursive {
+        dirs.sort_by(|a, b| a.file_name().cmp(&b.file_name()));
+        for sub_dir in dirs {
+            let sub_images = collect_images(&sub_dir, true)?;
+            result.extend(sub_images);
+        }
+    }
+
+    Ok(result)
+}
+
 /// フォルダ内の最初の画像ファイルパスを取得
 #[tauri::command]
-pub fn get_first_image_in_folder(folder_path: String) -> Result<Option<String>, String> {
+pub fn get_first_image_in_folder(folder_path: String, recursive: bool) -> Result<Option<String>, String> {
     let path = Path::new(&folder_path);
 
     if !path.exists() {
@@ -200,30 +245,8 @@ pub fn get_first_image_in_folder(folder_path: String) -> Result<Option<String>, 
         return Err(format!("指定されたパスはフォルダではありません: {}", folder_path));
     }
 
-    // ディレクトリ内のエントリを取得してソート
-    let mut entries: Vec<_> = fs::read_dir(path)
-        .map_err(|e| format!("フォルダの読み込みに失敗しました: {}", e))?
-        .filter_map(|entry| entry.ok())
-        .filter(|entry| {
-            if let Ok(file_type) = entry.file_type() {
-                if file_type.is_file() {
-                    if let Some(ext) = entry.path().extension() {
-                        let ext_lower = ext.to_string_lossy().to_lowercase();
-                        return IMAGE_EXTENSIONS.contains(&ext_lower.as_str());
-                    }
-                }
-            }
-            false
-        })
-        .collect();
-
-    // ファイル名でソート
-    entries.sort_by(|a, b| a.file_name().cmp(&b.file_name()));
-
-    // 最初の画像ファイルのパスを返す
-    Ok(entries
-        .first()
-        .map(|entry| entry.path().to_string_lossy().to_string()))
+    let images = collect_images(path, recursive)?;
+    Ok(images.first().map(|p| p.to_string_lossy().to_string()))
 }
 
 /// フォルダパスが有効かどうかを検証
@@ -240,9 +263,9 @@ pub struct ImageFile {
     pub filename: String,
 }
 
-/// フォルダ内のすべての画像ファイルを取得（ファイル名順でソート）
+/// フォルダ内のすべての画像ファイルを取得（ファイル名順でソート、再帰オプション付き）
 #[tauri::command]
-pub fn get_images_in_folder(folder_path: String) -> Result<Vec<ImageFile>, String> {
+pub fn get_images_in_folder(folder_path: String, recursive: bool) -> Result<Vec<ImageFile>, String> {
     let path = Path::new(&folder_path);
 
     if !path.exists() {
@@ -256,38 +279,16 @@ pub fn get_images_in_folder(folder_path: String) -> Result<Vec<ImageFile>, Strin
         ));
     }
 
-    // ディレクトリ内のエントリを取得
-    let mut entries: Vec<_> = fs::read_dir(path)
-        .map_err(|e| format!("フォルダの読み込みに失敗しました: {}", e))?
-        .filter_map(|entry| entry.ok())
-        .filter(|entry| {
-            if let Ok(file_type) = entry.file_type() {
-                if file_type.is_file() {
-                    if let Some(ext) = entry.path().extension() {
-                        let ext_lower = ext.to_string_lossy().to_lowercase();
-                        return IMAGE_EXTENSIONS.contains(&ext_lower.as_str());
-                    }
-                }
-            }
-            false
-        })
-        .collect();
+    let paths = collect_images(path, recursive)?;
 
-    // ファイル名でソート
-    entries.sort_by(|a, b| a.file_name().cmp(&b.file_name()));
-
-    // 画像ファイル情報を収集
-    let images: Vec<ImageFile> = entries
-        .iter()
-        .map(|entry| {
-            let file_path = entry.path();
-            ImageFile {
-                path: file_path.to_string_lossy().to_string(),
-                filename: file_path
-                    .file_name()
-                    .map(|n| n.to_string_lossy().to_string())
-                    .unwrap_or_default(),
-            }
+    let images: Vec<ImageFile> = paths
+        .into_iter()
+        .map(|file_path| ImageFile {
+            path: file_path.to_string_lossy().to_string(),
+            filename: file_path
+                .file_name()
+                .map(|n| n.to_string_lossy().to_string())
+                .unwrap_or_default(),
         })
         .collect();
 

--- a/image-folder-viewer/src-tauri/src/models/profile.rs
+++ b/image-folder-viewer/src-tauri/src/models/profile.rs
@@ -13,6 +13,9 @@ pub struct Card {
     pub sort_order: i32,
     pub created_at: String,
     pub updated_at: String,
+    /// サブディレクトリを含めて画像を検索するか（省略時 false、既存プロファイルとの後方互換）
+    #[serde(default)]
+    pub recursive: bool,
 }
 
 /// カード（検証結果付き）

--- a/image-folder-viewer/src/api/tauri.ts
+++ b/image-folder-viewer/src/api/tauri.ts
@@ -137,9 +137,10 @@ export async function getThumbnail(
  * @returns 最初の画像ファイルパス、画像がない場合はnull
  */
 export async function getFirstImageInFolder(
-  folderPath: string
+  folderPath: string,
+  recursive: boolean = false
 ): Promise<string | null> {
-  return invoke<string | null>("get_first_image_in_folder", { folderPath });
+  return invoke<string | null>("get_first_image_in_folder", { folderPath, recursive });
 }
 
 /**
@@ -157,9 +158,10 @@ export async function validateFolderPath(path: string): Promise<boolean> {
  * @returns 画像ファイル情報の配列
  */
 export async function getImagesInFolder(
-  folderPath: string
+  folderPath: string,
+  recursive: boolean = false
 ): Promise<ImageFile[]> {
-  return invoke<ImageFile[]>("get_images_in_folder", { folderPath });
+  return invoke<ImageFile[]>("get_images_in_folder", { folderPath, recursive });
 }
 
 // ========================================

--- a/image-folder-viewer/src/components/cards/CardAddModal.tsx
+++ b/image-folder-viewer/src/components/cards/CardAddModal.tsx
@@ -35,6 +35,7 @@ export const CardAddModal = ({ isOpen, onClose, onAdd }: CardAddModalProps) => {
   const [title, setTitle] = useState("");
   const [thumbnailPath, setThumbnailPath] = useState<string | null>(null);
   const [thumbnailUrl, setThumbnailUrl] = useState<string | null>(null);
+  const [recursive, setRecursive] = useState(false);
 
   // ローディング状態
   const [isSelectingFolder, setIsSelectingFolder] = useState(false);
@@ -51,6 +52,7 @@ export const CardAddModal = ({ isOpen, onClose, onAdd }: CardAddModalProps) => {
       setTitle("");
       setThumbnailPath(null);
       setThumbnailUrl(null);
+      setRecursive(false);
       setError(null);
     }
   }, [isOpen]);
@@ -124,6 +126,7 @@ export const CardAddModal = ({ isOpen, onClose, onAdd }: CardAddModalProps) => {
     }
   };
 
+
   // サムネイル変更
   const handleChangeThumbnail = async () => {
     setError(null);
@@ -146,6 +149,7 @@ export const CardAddModal = ({ isOpen, onClose, onAdd }: CardAddModalProps) => {
       folderPath,
       title: title.trim(),
       thumbnail: thumbnailPath,
+      recursive,
     });
     onClose();
   };
@@ -215,6 +219,15 @@ export const CardAddModal = ({ isOpen, onClose, onAdd }: CardAddModalProps) => {
           <div className="text-sm text-gray-600 bg-gray-50 px-3 py-2 rounded border border-gray-200 truncate">
             {folderPath}
           </div>
+          <label className="flex items-center gap-2 mt-2 cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={recursive}
+              onChange={(e) => setRecursive(e.target.checked)}
+              className="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+            />
+            <span className="text-sm text-gray-600">サブディレクトリの画像を含める</span>
+          </label>
         </div>
 
         {/* タイトル */}

--- a/image-folder-viewer/src/components/cards/CardEditModal.tsx
+++ b/image-folder-viewer/src/components/cards/CardEditModal.tsx
@@ -35,6 +35,7 @@ export const CardEditModal = ({
   const [folderPath, setFolderPath] = useState("");
   const [thumbnailPath, setThumbnailPath] = useState<string | null>(null);
   const [thumbnailUrl, setThumbnailUrl] = useState<string | null>(null);
+  const [recursive, setRecursive] = useState(false);
 
   // 編集状態追跡
   const [isFolderChanged, setIsFolderChanged] = useState(false);
@@ -51,6 +52,7 @@ export const CardEditModal = ({
       setTitle(card.title);
       setFolderPath(card.folderPath);
       setThumbnailPath(card.thumbnail);
+      setRecursive(card.recursive);
       setIsFolderChanged(false);
       setError(null);
     }
@@ -142,6 +144,11 @@ export const CardEditModal = ({
       input.thumbnail = thumbnailPath;
     }
 
+    // recursive が変更された場合
+    if (recursive !== card.recursive) {
+      input.recursive = recursive;
+    }
+
     onSave(card.id, input);
     onClose();
   };
@@ -218,6 +225,15 @@ export const CardEditModal = ({
               フォルダが変更されました
             </p>
           )}
+          <label className="flex items-center gap-2 mt-2 cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={recursive}
+              onChange={(e) => setRecursive(e.target.checked)}
+              className="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+            />
+            <span className="text-sm text-gray-600">サブディレクトリの画像を含める</span>
+          </label>
         </div>
 
         {/* タイトル */}

--- a/image-folder-viewer/src/pages/ViewerPage.tsx
+++ b/image-folder-viewer/src/pages/ViewerPage.tsx
@@ -304,6 +304,7 @@ export function ViewerPage() {
   // 画像一覧の読み込み（プリミティブ値を依存配列に使用し、不要な再読み込みを防止）
   const cardTitle = card?.title ?? "";
   const folderPath = card?.folderPath;
+  const recursive = card?.recursive ?? false;
 
   useEffect(() => {
     if (!cardId || !folderPath) return;
@@ -319,8 +320,9 @@ export function ViewerPage() {
       isRestore ? appState.lastImageIndex : 0,
       isRestore ? appState.hFlipEnabled : false,
       isRestore ? appState.shuffleEnabled : false,
+      recursive,
     );
-  }, [cardId, cardTitle, folderPath, loadImages]); // currentProfileは意図的に依存配列から除外
+  }, [cardId, cardTitle, folderPath, recursive, loadImages]); // currentProfileは意図的に依存配列から除外
 
   // プロファイルが読み込まれていない場合はStartupPageへ
   useEffect(() => {

--- a/image-folder-viewer/src/store/profileStore.ts
+++ b/image-folder-viewer/src/store/profileStore.ts
@@ -24,6 +24,7 @@ interface AddCardInput {
   folderPath: string;
   title: string;
   thumbnail: string | null;
+  recursive: boolean;
 }
 
 // カード更新時の入力データ（部分更新）
@@ -31,6 +32,7 @@ interface UpdateCardInput {
   title?: string;
   folderPath?: string;
   thumbnail?: string | null;
+  recursive?: boolean;
 }
 
 interface ProfileState {
@@ -273,6 +275,7 @@ export const useProfileStore = create<ProfileState & ProfileActions>(
         title: input.title,
         folderPath: input.folderPath,
         thumbnail: input.thumbnail,
+        recursive: input.recursive,
         sortOrder: maxSortOrder + 1,
         createdAt: now,
         updatedAt: now,

--- a/image-folder-viewer/src/store/viewerStore.ts
+++ b/image-folder-viewer/src/store/viewerStore.ts
@@ -40,7 +40,8 @@ interface ViewerActions {
     folderPath: string,
     initialIndex?: number,
     hFlip?: boolean,
-    shuffle?: boolean
+    shuffle?: boolean,
+    recursive?: boolean
   ) => Promise<void>;
 
   // ナビゲーション
@@ -106,11 +107,11 @@ export const useViewerStore = create<ViewerState & ViewerActions>((set, get) => 
   ...initialState,
 
   // 画像一覧を読み込む
-  loadImages: async (cardId, cardTitle, folderPath, initialIndex = 0, hFlip = false, shuffle = false) => {
+  loadImages: async (cardId, cardTitle, folderPath, initialIndex = 0, hFlip = false, shuffle = false, recursive = false) => {
     set({ isLoading: true, error: null });
 
     try {
-      const images = await getImagesInFolder(folderPath);
+      const images = await getImagesInFolder(folderPath, recursive);
 
       if (images.length === 0) {
         set({

--- a/image-folder-viewer/src/types/index.ts
+++ b/image-folder-viewer/src/types/index.ts
@@ -9,6 +9,8 @@ export interface Card {
   sortOrder: number;
   createdAt: string;
   updatedAt: string;
+  /** サブディレクトリを含めて画像を検索するか */
+  recursive: boolean;
 }
 
 // カード（検証結果付き）


### PR DESCRIPTION
## Summary
- `Card` モデルに `recursive` フィールドを追加（`#[serde(default)]` で既存 `.ivprofile` との後方互換を保つ）
- `get_first_image_in_folder` / `get_images_in_folder` コマンドに再帰検索対応を追加
- CardAddModal・CardEditModal のフォルダセクションにチェックボックス「サブディレクトリの画像を含める」を追加
- ビューアでの画像読み込み（`loadImages`）に `recursive` フラグを反映

## Test plan
- [ ] 既存カード（`recursive` フィールドなし）が従来通り動作する
- [ ] CardAddModal でチェックボックスをオンにしてカードを追加すると、サブディレクトリの画像もビューアに表示される
- [ ] CardEditModal でチェックボックスを変更して保存すると、`.ivprofile` に反映され再起動後も復元される
- [ ] チェックボックスのオン・オフでサムネイルは変化しない（サムネイルはユーザーが明示的に選択するもの）

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)