### PR TITLE
feat: トースト通知 (#5 #6 #7)

### DIFF
--- a/image-folder-viewer/src-tauri/src/commands/clipboard.rs
+++ b/image-folder-viewer/src-tauri/src/commands/clipboard.rs
@@ -10,9 +10,9 @@ use std::path::Path;
 use std::sync::Mutex;
 
 /// グローバルClipboardインスタンス（Linux/X11対策）
-static CLIPBOARD: Lazy<Mutex<Clipboard>> = Lazy::new(|| {
-    Mutex::new(Clipboard::new().expect("クリップボードの初期化に失敗しました"))
-});
+/// 初期化失敗時は None を格納し、各コマンドでエラーとして返す
+static CLIPBOARD: Lazy<Mutex<Option<Clipboard>>> =
+    Lazy::new(|| Mutex::new(Clipboard::new().ok()));
 
 /// 画像をクリップボードにコピー
 #[tauri::command]
@@ -34,9 +34,12 @@ pub fn copy_image_to_clipboard(image_path: String) -> Result<(), String> {
     let (width, height) = rgba.dimensions();
 
     // クリップボードに設定
-    let mut clipboard = CLIPBOARD
+    let mut clipboard_guard = CLIPBOARD
         .lock()
         .map_err(|e| format!("クリップボードのロックに失敗しました: {}", e))?;
+    let clipboard = clipboard_guard
+        .as_mut()
+        .ok_or_else(|| "クリップボードが利用できません".to_string())?;
 
     let image_data = arboard::ImageData {
         width: width as usize,
@@ -54,9 +57,12 @@ pub fn copy_image_to_clipboard(image_path: String) -> Result<(), String> {
 /// テキストをクリップボードにコピー（パスコピー用）
 #[tauri::command]
 pub fn copy_text_to_clipboard(text: String) -> Result<(), String> {
-    let mut clipboard = CLIPBOARD
+    let mut clipboard_guard = CLIPBOARD
         .lock()
         .map_err(|e| format!("クリップボードのロックに失敗しました: {}", e))?;
+    let clipboard = clipboard_guard
+        .as_mut()
+        .ok_or_else(|| "クリップボードが利用できません".to_string())?;
 
     clipboard
         .set_text(text)

--- a/image-folder-viewer/src/App.tsx
+++ b/image-folder-viewer/src/App.tsx
@@ -6,6 +6,7 @@ import { getCurrentWindow } from "@tauri-apps/api/window";
 import { IndexPage } from "./pages/IndexPage";
 import { ViewerPage } from "./pages/ViewerPage";
 import { StartupPage } from "./pages/StartupPage";
+import { Toast } from "./components/common/Toast";
 import { useProfileStore } from "./store/profileStore";
 import { saveProfile } from "./api/tauri";
 
@@ -51,13 +52,16 @@ function App() {
   }, []);
 
   return (
-    <Routes>
-      <Route path="/startup" element={<StartupPage />} />
-      <Route path="/" element={<IndexPage />} />
-      <Route path="/viewer/:cardId" element={<ViewerPage />} />
-      {/* 未知のパスはStartupPageへリダイレクト */}
-      <Route path="*" element={<Navigate to="/startup" replace />} />
-    </Routes>
+    <>
+      <Routes>
+        <Route path="/startup" element={<StartupPage />} />
+        <Route path="/" element={<IndexPage />} />
+        <Route path="/viewer/:cardId" element={<ViewerPage />} />
+        {/* 未知のパスはStartupPageへリダイレクト */}
+        <Route path="*" element={<Navigate to="/startup" replace />} />
+      </Routes>
+      <Toast />
+    </>
   );
 }
 

--- a/image-folder-viewer/src/App.tsx
+++ b/image-folder-viewer/src/App.tsx
@@ -7,6 +7,7 @@ import { IndexPage } from "./pages/IndexPage";
 import { ViewerPage } from "./pages/ViewerPage";
 import { StartupPage } from "./pages/StartupPage";
 import { Toast } from "./components/common/Toast";
+import { ToastTest } from "./components/common/ToastTest";
 import { useProfileStore } from "./store/profileStore";
 import { saveProfile } from "./api/tauri";
 
@@ -61,6 +62,7 @@ function App() {
         <Route path="*" element={<Navigate to="/startup" replace />} />
       </Routes>
       <Toast />
+      {import.meta.env.DEV && <ToastTest />}
     </>
   );
 }

--- a/image-folder-viewer/src/components/common/Toast.tsx
+++ b/image-folder-viewer/src/components/common/Toast.tsx
@@ -1,0 +1,51 @@
+// トースト通知コンポーネント
+
+import { useEffect } from "react";
+import { X } from "lucide-react";
+import { useToastStore, type Toast } from "../../store/toastStore";
+
+const TOAST_DURATION_MS = 3000;
+
+const typeStyles: Record<Toast["type"], string> = {
+  success: "bg-green-600 text-white",
+  error: "bg-red-600 text-white",
+  info: "bg-gray-700 text-white",
+};
+
+function ToastItem({ toast }: { toast: Toast }) {
+  const removeToast = useToastStore((state) => state.removeToast);
+
+  useEffect(() => {
+    const timer = setTimeout(() => removeToast(toast.id), TOAST_DURATION_MS);
+    return () => clearTimeout(timer);
+  }, [toast.id, removeToast]);
+
+  return (
+    <div
+      className={`flex items-start gap-2 px-4 py-3 rounded-lg shadow-lg max-w-sm pointer-events-auto ${typeStyles[toast.type]}`}
+    >
+      <span className="flex-1 text-sm">{toast.message}</span>
+      <button
+        onClick={() => removeToast(toast.id)}
+        className="shrink-0 opacity-75 hover:opacity-100 transition-opacity"
+        aria-label="閉じる"
+      >
+        <X size={16} />
+      </button>
+    </div>
+  );
+}
+
+export function Toast() {
+  const toasts = useToastStore((state) => state.toasts);
+
+  if (toasts.length === 0) return null;
+
+  return (
+    <div className="fixed bottom-4 right-4 z-50 flex flex-col gap-2 pointer-events-none">
+      {toasts.map((toast) => (
+        <ToastItem key={toast.id} toast={toast} />
+      ))}
+    </div>
+  );
+}

--- a/image-folder-viewer/src/components/common/ToastTest.tsx
+++ b/image-folder-viewer/src/components/common/ToastTest.tsx
@@ -1,0 +1,42 @@
+// 開発テスト用: トースト通知UIの目視確認コンポーネント
+// 確認後は git reset で削除すること
+
+import { useToastStore } from "../../store/toastStore";
+
+export function ToastTest() {
+  const addToast = useToastStore((state) => state.addToast);
+
+  return (
+    <div className="fixed top-4 left-4 z-50 flex flex-col gap-2 bg-white border border-gray-300 rounded-lg p-3 shadow-lg text-sm">
+      <p className="font-bold text-gray-500 text-xs">Toast テスト</p>
+      <button
+        onClick={() => addToast("画像をクリップボードにコピーしました", "success")}
+        className="px-3 py-1 bg-green-100 hover:bg-green-200 text-green-800 rounded"
+      >
+        success
+      </button>
+      <button
+        onClick={() => addToast("プロファイルの保存に失敗しました: 書き込み権限がありません", "error")}
+        className="px-3 py-1 bg-red-100 hover:bg-red-200 text-red-800 rounded"
+      >
+        error
+      </button>
+      <button
+        onClick={() => addToast("情報メッセージのサンプルです", "info")}
+        className="px-3 py-1 bg-gray-100 hover:bg-gray-200 text-gray-800 rounded"
+      >
+        info
+      </button>
+      <button
+        onClick={() => {
+          addToast("メッセージ1件目", "success");
+          addToast("メッセージ2件目（エラー）", "error");
+          addToast("メッセージ3件目", "info");
+        }}
+        className="px-3 py-1 bg-blue-100 hover:bg-blue-200 text-blue-800 rounded"
+      >
+        複数同時
+      </button>
+    </div>
+  );
+}

--- a/image-folder-viewer/src/pages/ViewerPage.tsx
+++ b/image-folder-viewer/src/pages/ViewerPage.tsx
@@ -20,6 +20,7 @@ import {
   useViewerStore,
 } from "../store/viewerStore";
 import { copyImageToClipboard, copyTextToClipboard } from "../api/tauri";
+import { useToastStore } from "../store/toastStore";
 
 // フィットズーム率を計算
 function calculateFitZoom(displayW: number, displayH: number, imageW: number, imageH: number): number {
@@ -47,6 +48,7 @@ export function ViewerPage() {
   const error = useViewerStore((state) => state.error);
   const zoomLevel = useViewerStore((state) => state.zoomLevel);
   const originalImageSize = useViewerStore((state) => state.originalImageSize);
+  const addToast = useToastStore((state) => state.addToast);
 
   // コンテキストメニュー状態
   const [contextMenu, setContextMenu] = useState<{
@@ -272,10 +274,10 @@ export function ViewerPage() {
       useProfileStore.getState();
     if (profile && path) {
       saveProfile(path, profile).catch((e) =>
-        console.error("プロファイル保存に失敗:", e)
+        addToast(`プロファイルの保存に失敗しました: ${e}`, "error")
       );
     }
-  }, [updateAppState]);
+  }, [updateAppState, addToast]);
 
   // 画像表示・オプション変更時にビューア状態を保存
   useEffect(() => {
@@ -293,13 +295,13 @@ export function ViewerPage() {
       useProfileStore.getState();
     if (profile && path) {
       saveProfile(path, profile).catch((e) =>
-        console.error("プロファイル保存に失敗:", e)
+        addToast(`プロファイルの保存に失敗しました: ${e}`, "error")
       );
     }
 
     reset();
     navigate("/");
-  }, [navigate, reset, updateAppState]);
+  }, [navigate, reset, updateAppState, addToast]);
 
   // 画像一覧の読み込み（プリミティブ値を依存配列に使用し、不要な再読み込みを防止）
   const cardTitle = card?.title ?? "";
@@ -428,18 +430,18 @@ export function ViewerPage() {
         label: "コピー",
         shortcut: "",
         onClick: () => {
-          copyImageToClipboard(imagePath).catch((e) =>
-            console.error("画像コピーに失敗:", e)
-          );
+          copyImageToClipboard(imagePath)
+            .then(() => addToast("画像をクリップボードにコピーしました", "success"))
+            .catch((e) => addToast(`画像のコピーに失敗しました: ${e}`, "error"));
         },
       });
       items.push({
         label: "パスをコピー",
         shortcut: "",
         onClick: () => {
-          copyTextToClipboard(imagePath).catch((e) =>
-            console.error("パスコピーに失敗:", e)
-          );
+          copyTextToClipboard(imagePath)
+            .then(() => addToast("パスをクリップボードにコピーしました", "success"))
+            .catch((e) => addToast(`パスのコピーに失敗しました: ${e}`, "error"));
         },
       });
     }
@@ -489,7 +491,7 @@ export function ViewerPage() {
     });
 
     return items;
-  }, [imagePath, hFlipEnabled, shuffleEnabled, toggleHFlip, toggleShuffle, handleZoomIn, handleZoomOut, handleResetZoom, handleBack]);
+  }, [imagePath, hFlipEnabled, shuffleEnabled, toggleHFlip, toggleShuffle, handleZoomIn, handleZoomOut, handleResetZoom, handleBack, addToast]);
 
   // カードが見つからない場合
   if (!card) {

--- a/image-folder-viewer/src/store/toastStore.ts
+++ b/image-folder-viewer/src/store/toastStore.ts
@@ -1,0 +1,34 @@
+// トースト通知状態管理
+
+import { create } from "zustand";
+
+export type ToastType = "success" | "error" | "info";
+
+export interface Toast {
+  id: string;
+  message: string;
+  type: ToastType;
+}
+
+interface ToastStore {
+  toasts: Toast[];
+  addToast: (message: string, type?: ToastType) => void;
+  removeToast: (id: string) => void;
+}
+
+export const useToastStore = create<ToastStore>((set) => ({
+  toasts: [],
+
+  addToast: (message, type = "info") => {
+    const id = crypto.randomUUID();
+    set((state) => ({
+      toasts: [...state.toasts, { id, message, type }],
+    }));
+  },
+
+  removeToast: (id) => {
+    set((state) => ({
+      toasts: state.toasts.filter((t) => t.id !== id),
+    }));
+  },
+}));


### PR DESCRIPTION
## 概要

- #5 プロファイル保存失敗時のトースト通知（ViewerPage）
- #6 クリップボードコピー成功・失敗のトースト通知
- #7 Clipboard 初期化エラーの panic 除去（グレースフル対応）

## 変更内容

### 新規ファイル

- `src/store/toastStore.ts` — Toast 状態管理（Zustand）
- `src/components/common/Toast.tsx` — トースト表示コンポーネント（右下固定、3秒自動消去、type別色分け）
- `src/components/common/ToastTest.tsx` — 開発用テストパネル（`import.meta.env.DEV` のみ表示、本番ビルドでは除外）

### 変更ファイル

- `src/App.tsx` — `<Toast />` と `<ToastTest />` を全ページ共通で配置
- `src/pages/ViewerPage.tsx` — プロファイル保存失敗・クリップボード操作の結果をトーストで通知
- `src-tauri/src/commands/clipboard.rs` — `expect()` を除去、`Lazy<Mutex<Option<Clipboard>>>` に変更し初期化失敗時もパニックしないよう修正

## テスト

- `npm run tauri dev` 起動時に左上のテストパネルで各 toast タイプ（success / error / info / 複数同時）を目視確認済み