### PR TITLE
fix: ビューア復元エラー時の自動遷移とファイル名マッチング (#8 #9)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ Thumbs.db
 
 # Local config
 *.local
+
+# テスト用一時ディレクトリ
+tmp/

--- a/image-folder-viewer/src-tauri/src/models/profile.rs
+++ b/image-folder-viewer/src-tauri/src/models/profile.rs
@@ -73,6 +73,8 @@ pub struct AppState {
     pub last_page: String, // "index" | "viewer"
     pub last_card_id: Option<String>,
     pub last_image_index: i32,
+    #[serde(default)]
+    pub last_image_filename: Option<String>,
     pub h_flip_enabled: bool,
     pub shuffle_enabled: bool,
     pub window: WindowState,
@@ -84,6 +86,7 @@ impl Default for AppState {
             last_page: "index".to_string(),
             last_card_id: None,
             last_image_index: 0,
+            last_image_filename: None,
             h_flip_enabled: false,
             shuffle_enabled: false,
             window: WindowState::default(),

--- a/image-folder-viewer/src/pages/ViewerPage.tsx
+++ b/image-folder-viewer/src/pages/ViewerPage.tsx
@@ -265,6 +265,7 @@ export function ViewerPage() {
       lastPage: "viewer",
       lastCardId: viewerState.cardId,
       lastImageIndex: imageIndex,
+      lastImageFilename: viewerState.images[imageIndex]?.filename,
       hFlipEnabled: viewerState.hFlipEnabled,
       shuffleEnabled: viewerState.shuffleEnabled,
     });
@@ -323,6 +324,7 @@ export function ViewerPage() {
       isRestore ? appState.hFlipEnabled : false,
       isRestore ? appState.shuffleEnabled : false,
       recursive,
+      isRestore ? appState.lastImageFilename : undefined,
     );
   }, [cardId, cardTitle, folderPath, recursive, loadImages]); // currentProfileは意図的に依存配列から除外
 
@@ -339,6 +341,16 @@ export function ViewerPage() {
       navigate("/");
     }
   }, [currentProfile, card, navigate]);
+
+  // 画像読み込みエラー時はトーストを表示してIndexPageへ自動遷移（#9）
+  // updateAppState で lastPage を "index" にリセットしないと、IndexPage が再び ViewerPage に戻してしまう
+  useEffect(() => {
+    if (!error) return;
+    addToast(error, "error");
+    updateAppState({ lastPage: "index" });
+    reset();
+    navigate("/");
+  }, [error, addToast, navigate, updateAppState, reset]);
 
   // キーボードショートカット
   useEffect(() => {

--- a/image-folder-viewer/src/store/viewerStore.ts
+++ b/image-folder-viewer/src/store/viewerStore.ts
@@ -41,7 +41,8 @@ interface ViewerActions {
     initialIndex?: number,
     hFlip?: boolean,
     shuffle?: boolean,
-    recursive?: boolean
+    recursive?: boolean,
+    targetFilename?: string
   ) => Promise<void>;
 
   // ナビゲーション
@@ -107,7 +108,7 @@ export const useViewerStore = create<ViewerState & ViewerActions>((set, get) => 
   ...initialState,
 
   // 画像一覧を読み込む
-  loadImages: async (cardId, cardTitle, folderPath, initialIndex = 0, hFlip = false, shuffle = false, recursive = false) => {
+  loadImages: async (cardId, cardTitle, folderPath, initialIndex = 0, hFlip = false, shuffle = false, recursive = false, targetFilename?: string) => {
     set({ isLoading: true, error: null });
 
     try {
@@ -125,8 +126,26 @@ export const useViewerStore = create<ViewerState & ViewerActions>((set, get) => 
         return;
       }
 
+      // ファイル名指定がある場合はファイル名でマッチング（復元時）
+      let resolvedIndex = initialIndex;
+      if (targetFilename) {
+        const found = images.findIndex((img) => img.filename === targetFilename);
+        if (found === -1) {
+          set({
+            ...initialState,
+            cardId,
+            cardTitle,
+            folderPath,
+            error: `前回の画像が見つかりません: ${targetFilename}`,
+            isLoading: false,
+          });
+          return;
+        }
+        resolvedIndex = found;
+      }
+
       // 初期インデックスを範囲内に収める
-      const validIndex = Math.max(0, Math.min(initialIndex, images.length - 1));
+      const validIndex = Math.max(0, Math.min(resolvedIndex, images.length - 1));
 
       // シャッフルが有効な場合はインデックス配列を生成
       const shuffledIndices = shuffle

--- a/image-folder-viewer/src/types/index.ts
+++ b/image-folder-viewer/src/types/index.ts
@@ -45,6 +45,7 @@ export interface AppState {
   lastPage: "index" | "viewer";
   lastCardId: string | null;
   lastImageIndex: number;
+  lastImageFilename?: string;
   hFlipEnabled: boolean;
   shuffleEnabled: boolean;
   window: WindowState;


### PR DESCRIPTION
## 概要

- #8 ビューア復元時のファイル不一致対応（`lastImageFilename` による検証）
- #9 ビューア復元時のフォルダ不存在で IndexPage に自動遷移

## 変更内容

### #8 ファイル名による復元検証

- `src-tauri/src/models/profile.rs` — `AppState` に `last_image_filename: Option<String>` を追加（`#[serde(default)]` で既存 .ivprofile と後方互換）
- `src/types/index.ts` — `AppState` に `lastImageFilename?: string` を追加
- `src/store/viewerStore.ts` — `loadImages` に `targetFilename?` 引数を追加。ファイル名マッチング失敗時はエラー状態をセット
- `src/pages/ViewerPage.tsx` — 状態保存時に `lastImageFilename` を記録、復元時にファイル名を `loadImages` へ渡す

### #9 エラー時の自動遷移

- `src/pages/ViewerPage.tsx` — `viewerStore.error` を監視する `useEffect` を追加。エラー発生時にトーストを表示し、`lastPage` を `"index"` にリセットしてから `/` へ自動遷移（`lastPage` をリセットしないと IndexPage が再び ViewerPage へ戻してしまう無限ループが発生するため）

### その他

- `.gitignore` — テスト用 `tmp/` ディレクトリを追加

## 既知の制限

開発モード（`npm run tauri dev`）では React StrictMode により `loadImages` が2回呼ばれるため、エラートーストが2枚表示される場合がある。本番ビルドでは発生しない。