### PR TITLE
feat: カスタム確認モーダルの実装（window.confirm() 置き換え）

### DIFF
--- a/image-folder-viewer/src/components/common/ConfirmModal.tsx
+++ b/image-folder-viewer/src/components/common/ConfirmModal.tsx
@@ -1,0 +1,52 @@
+// 確認ダイアログモーダル（window.confirm() の代替）
+
+import { Modal, Button } from "./Modal";
+
+interface ConfirmModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  title: string;
+  message: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  variant?: "danger" | "primary";
+}
+
+export const ConfirmModal = ({
+  isOpen,
+  onClose,
+  onConfirm,
+  title,
+  message,
+  confirmLabel = "確認",
+  cancelLabel = "キャンセル",
+  variant = "danger",
+}: ConfirmModalProps) => {
+  const handleConfirm = () => {
+    onConfirm();
+    onClose();
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={title}
+      width="sm"
+      closeOnOverlay={false}
+      footer={
+        <>
+          <Button variant="secondary" onClick={onClose}>
+            {cancelLabel}
+          </Button>
+          <Button variant={variant} onClick={handleConfirm}>
+            {confirmLabel}
+          </Button>
+        </>
+      }
+    >
+      <p className="text-gray-700">{message}</p>
+    </Modal>
+  );
+};

--- a/image-folder-viewer/src/pages/IndexPage.tsx
+++ b/image-folder-viewer/src/pages/IndexPage.tsx
@@ -8,6 +8,7 @@ import { CardGrid, type CardValidation } from "../components/cards/CardGrid";
 import { CardAddModal } from "../components/cards/CardAddModal";
 import { CardEditModal } from "../components/cards/CardEditModal";
 import { Spinner } from "../components/common/Spinner";
+import { ConfirmModal } from "../components/common/ConfirmModal";
 import {
   useProfileStore,
   useCards,
@@ -45,6 +46,7 @@ export function IndexPage() {
   // モーダル状態
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
   const [editingCard, setEditingCard] = useState<Card | null>(null);
+  const [deletingCard, setDeletingCard] = useState<Card | null>(null);
 
   // 選択状態
   const [selectedCardId, setSelectedCardId] = useState<string | null>(null);
@@ -173,17 +175,19 @@ export function IndexPage() {
     setEditingCard(card);
   }, []);
 
-  // カード削除
-  const handleCardDelete = useCallback(
-    (card: Card) => {
-      if (window.confirm(`「${card.title}」を削除しますか？`)) {
-        deleteCard(card.id);
-        // 自動保存
-        saveCurrentProfile();
-      }
-    },
-    [deleteCard, saveCurrentProfile]
-  );
+  // カード削除（確認モーダルを表示）
+  const handleCardDelete = useCallback((card: Card) => {
+    setDeletingCard(card);
+  }, []);
+
+  // カード削除確認後の実行
+  const handleCardDeleteConfirm = useCallback(() => {
+    if (!deletingCard) return;
+    deleteCard(deletingCard.id);
+    // 自動保存
+    saveCurrentProfile();
+    setDeletingCard(null);
+  }, [deletingCard, deleteCard, saveCurrentProfile]);
 
   // カード追加
   const handleAddCard = useCallback(
@@ -228,7 +232,7 @@ export function IndexPage() {
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       // モーダルが開いている場合は無視
-      if (isAddModalOpen || editingCard) return;
+      if (isAddModalOpen || editingCard || deletingCard) return;
 
       // Ctrl+S: 保存
       if (e.ctrlKey && e.key === "s") {
@@ -313,6 +317,7 @@ export function IndexPage() {
   }, [
     isAddModalOpen,
     editingCard,
+    deletingCard,
     saveCurrentProfile,
     selectedCardId,
     cards,
@@ -398,6 +403,16 @@ export function IndexPage() {
         card={editingCard}
         isValid={editingCardValidation}
         onSave={handleUpdateCard}
+      />
+
+      {/* カード削除確認モーダル */}
+      <ConfirmModal
+        isOpen={deletingCard !== null}
+        onClose={() => setDeletingCard(null)}
+        onConfirm={handleCardDeleteConfirm}
+        title="カードの削除"
+        message={`「${deletingCard?.title}」を削除しますか？`}
+        confirmLabel="削除"
       />
     </div>
   );


### PR DESCRIPTION
## Summary

- `window.confirm()` は Tauri v2 WebView（Linux/WebKit）でユーザーの選択に関わらず `true` を返すため、カスタム確認モーダルで置き換え（closes #10）
- `ConfirmModal.tsx` を新規作成（既存の `Modal` / `Button` コンポーネントを流用、汎用設計）
- `IndexPage.tsx` の削除確認処理を `ConfirmModal` に移行、Delete キーの二重発火も防止

## Test plan

- [ ] カードコンテキストメニューの「削除」→ 確認モーダルが表示されること
- [ ] 確認モーダルで「削除」→ カードが削除されること
- [ ] 確認モーダルで「キャンセル」→ カードが削除されないこと
- [ ] Delete キーでの削除（確認モーダル表示 → 確認 / キャンセル）が正しく動作すること
- [ ] 確認モーダルが開いている間、Delete キーが再トリガーされないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)