### PR TITLE
feat: カラーテーマ基盤実装（light/dark）#17

### DIFF
--- a/image-folder-viewer/src-tauri/src/models/app_config.rs
+++ b/image-folder-viewer/src-tauri/src/models/app_config.rs
@@ -9,7 +9,7 @@ fn default_max_recent_profiles() -> i32 {
     10
 }
 fn default_theme() -> String {
-    "system".to_string()
+    "dark".to_string()
 }
 fn default_true() -> bool {
     true
@@ -41,7 +41,7 @@ pub struct AppConfig {
     /// 履歴の最大保持数
     #[serde(default = "default_max_recent_profiles")]
     pub max_recent_profiles: i32,
-    /// テーマ設定 ("light" | "dark" | "system")
+    /// テーマ設定 ("light" | "dark")
     #[serde(default = "default_theme")]
     pub theme: String,
     /// 起動時にウィンドウを最前面に表示する（Linux のフォーカス盗み防止対策）

--- a/image-folder-viewer/src/components/cards/CardAddModal.tsx
+++ b/image-folder-viewer/src/components/cards/CardAddModal.tsx
@@ -160,16 +160,16 @@ export const CardAddModal = ({ isOpen, onClose, onAdd }: CardAddModalProps) => {
       <Modal isOpen={isOpen} onClose={onClose} title="新規カード作成" width="sm">
         <div className="flex flex-col items-center justify-center py-8 gap-4">
           {error && (
-            <div className="w-full flex items-start gap-2 p-3 bg-red-50 border border-red-200 rounded text-red-700 text-sm">
+            <div className="w-full flex items-start gap-2 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded text-red-700 dark:text-red-400 text-sm">
               <AlertTriangle size={18} className="flex-shrink-0 mt-0.5" />
               <span>{error}</span>
             </div>
           )}
           {isSelectingFolder ? (
-            <div className="text-gray-500">フォルダを選択してください...</div>
+            <div className="text-gray-500 dark:text-gray-400">フォルダを選択してください...</div>
           ) : (
             <>
-              <FolderOpen size={48} className="text-gray-300" />
+              <FolderOpen size={48} className="text-gray-300 dark:text-gray-600" />
               <Button variant="primary" onClick={handleSelectFolder}>
                 フォルダを選択
               </Button>
@@ -205,7 +205,7 @@ export const CardAddModal = ({ isOpen, onClose, onAdd }: CardAddModalProps) => {
       <div className="space-y-4">
         {/* エラーメッセージ */}
         {error && (
-          <div className="flex items-start gap-2 p-3 bg-red-50 border border-red-200 rounded text-red-700 text-sm">
+          <div className="flex items-start gap-2 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded text-red-700 dark:text-red-400 text-sm">
             <AlertTriangle size={18} className="flex-shrink-0 mt-0.5" />
             <span>{error}</span>
           </div>
@@ -213,10 +213,10 @@ export const CardAddModal = ({ isOpen, onClose, onAdd }: CardAddModalProps) => {
 
         {/* フォルダパス */}
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
             フォルダ
           </label>
-          <div className="text-sm text-gray-600 bg-gray-50 px-3 py-2 rounded border border-gray-200 truncate">
+          <div className="text-sm text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-700 px-3 py-2 rounded border border-gray-200 dark:border-gray-600 truncate">
             {folderPath}
           </div>
           <label className="flex items-center gap-2 mt-2 cursor-pointer select-none">
@@ -226,7 +226,7 @@ export const CardAddModal = ({ isOpen, onClose, onAdd }: CardAddModalProps) => {
               onChange={(e) => setRecursive(e.target.checked)}
               className="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
             />
-            <span className="text-sm text-gray-600">サブディレクトリの画像を含める</span>
+            <span className="text-sm text-gray-600 dark:text-gray-400">サブディレクトリの画像を含める</span>
           </label>
         </div>
 
@@ -234,7 +234,7 @@ export const CardAddModal = ({ isOpen, onClose, onAdd }: CardAddModalProps) => {
         <div>
           <label
             htmlFor="card-title"
-            className="block text-sm font-medium text-gray-700 mb-1"
+            className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
           >
             タイトル
           </label>
@@ -243,7 +243,7 @@ export const CardAddModal = ({ isOpen, onClose, onAdd }: CardAddModalProps) => {
             type="text"
             value={title}
             onChange={(e) => setTitle(e.target.value)}
-            className="w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 rounded focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
             placeholder="カードのタイトル"
             autoFocus
           />
@@ -251,14 +251,14 @@ export const CardAddModal = ({ isOpen, onClose, onAdd }: CardAddModalProps) => {
 
         {/* サムネイル */}
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
             サムネイル
           </label>
           <div className="flex items-start gap-4">
             {/* プレビュー */}
-            <div className="w-24 h-24 bg-gray-100 rounded border border-gray-200 flex items-center justify-center overflow-hidden flex-shrink-0">
+            <div className="w-24 h-24 bg-gray-100 dark:bg-gray-700 rounded border border-gray-200 dark:border-gray-600 flex items-center justify-center overflow-hidden flex-shrink-0">
               {isLoadingThumbnail ? (
-                <div className="animate-pulse bg-gray-200 w-full h-full" />
+                <div className="animate-pulse bg-gray-200 dark:bg-gray-600 w-full h-full" />
               ) : thumbnailUrl ? (
                 <img
                   src={thumbnailUrl}
@@ -266,7 +266,7 @@ export const CardAddModal = ({ isOpen, onClose, onAdd }: CardAddModalProps) => {
                   className="w-full h-full object-cover"
                 />
               ) : (
-                <ImageIcon size={32} className="text-gray-300" />
+                <ImageIcon size={32} className="text-gray-300 dark:text-gray-600" />
               )}
             </div>
 
@@ -275,7 +275,7 @@ export const CardAddModal = ({ isOpen, onClose, onAdd }: CardAddModalProps) => {
               <Button variant="secondary" onClick={handleChangeThumbnail}>
                 変更...
               </Button>
-              <p className="text-xs text-gray-500">
+              <p className="text-xs text-gray-500 dark:text-gray-400">
                 任意の画像ファイルを選択できます
               </p>
             </div>

--- a/image-folder-viewer/src/components/cards/CardEditModal.tsx
+++ b/image-folder-viewer/src/components/cards/CardEditModal.tsx
@@ -179,7 +179,7 @@ export const CardEditModal = ({
       <div className="space-y-4">
         {/* 操作エラーメッセージ */}
         {error && (
-          <div className="flex items-start gap-2 p-3 bg-red-50 border border-red-200 rounded text-red-700 text-sm">
+          <div className="flex items-start gap-2 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded text-red-700 dark:text-red-400 text-sm">
             <AlertTriangle size={18} className="flex-shrink-0 mt-0.5" />
             <span>{error}</span>
           </div>
@@ -187,7 +187,7 @@ export const CardEditModal = ({
 
         {/* エラー状態の警告 */}
         {!isValid && !isFolderChanged && (
-          <div className="flex items-center gap-2 p-3 bg-red-50 border border-red-200 rounded text-red-700 text-sm">
+          <div className="flex items-center gap-2 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded text-red-700 dark:text-red-400 text-sm">
             <AlertTriangle size={18} />
             <span>フォルダが見つかりません。パスを変更してください。</span>
           </div>
@@ -195,15 +195,15 @@ export const CardEditModal = ({
 
         {/* フォルダパス */}
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
             フォルダ
           </label>
           <div className="flex items-center gap-2">
             <div
               className={`flex-1 text-sm px-3 py-2 rounded border truncate ${
                 !isValid && !isFolderChanged
-                  ? "bg-red-50 border-red-300 text-red-700"
-                  : "bg-gray-50 border-gray-200 text-gray-600"
+                  ? "bg-red-50 border-red-300 text-red-700 dark:bg-red-900/20 dark:border-red-800 dark:text-red-400"
+                  : "bg-gray-50 border-gray-200 text-gray-600 dark:bg-gray-700 dark:border-gray-600 dark:text-gray-400"
               }`}
             >
               {folderPath}
@@ -213,7 +213,7 @@ export const CardEditModal = ({
               <button
                 type="button"
                 onClick={handleChangeFolder}
-                className="p-2 text-gray-500 hover:text-blue-600 hover:bg-blue-50 rounded transition-colors"
+                className="p-2 text-gray-500 hover:text-blue-600 hover:bg-blue-50 dark:text-gray-400 dark:hover:text-blue-400 dark:hover:bg-blue-900 rounded transition-colors"
                 title="フォルダを変更"
               >
                 <FolderOpen size={20} />
@@ -232,7 +232,7 @@ export const CardEditModal = ({
               onChange={(e) => setRecursive(e.target.checked)}
               className="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
             />
-            <span className="text-sm text-gray-600">サブディレクトリの画像を含める</span>
+            <span className="text-sm text-gray-600 dark:text-gray-400">サブディレクトリの画像を含める</span>
           </label>
         </div>
 
@@ -240,7 +240,7 @@ export const CardEditModal = ({
         <div>
           <label
             htmlFor="edit-card-title"
-            className="block text-sm font-medium text-gray-700 mb-1"
+            className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
           >
             タイトル
           </label>
@@ -249,7 +249,7 @@ export const CardEditModal = ({
             type="text"
             value={title}
             onChange={(e) => setTitle(e.target.value)}
-            className="w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 rounded focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
             placeholder="カードのタイトル"
             autoFocus
           />
@@ -257,14 +257,14 @@ export const CardEditModal = ({
 
         {/* サムネイル */}
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
             サムネイル
           </label>
           <div className="flex items-start gap-4">
             {/* プレビュー */}
-            <div className="w-24 h-24 bg-gray-100 rounded border border-gray-200 flex items-center justify-center overflow-hidden flex-shrink-0">
+            <div className="w-24 h-24 bg-gray-100 dark:bg-gray-700 rounded border border-gray-200 dark:border-gray-600 flex items-center justify-center overflow-hidden flex-shrink-0">
               {isLoadingThumbnail ? (
-                <div className="animate-pulse bg-gray-200 w-full h-full" />
+                <div className="animate-pulse bg-gray-200 dark:bg-gray-600 w-full h-full" />
               ) : thumbnailUrl ? (
                 <img
                   src={thumbnailUrl}
@@ -272,7 +272,7 @@ export const CardEditModal = ({
                   className="w-full h-full object-cover"
                 />
               ) : (
-                <ImageIcon size={32} className="text-gray-300" />
+                <ImageIcon size={32} className="text-gray-300 dark:text-gray-600" />
               )}
             </div>
 
@@ -285,7 +285,7 @@ export const CardEditModal = ({
               >
                 変更...
               </Button>
-              <p className="text-xs text-gray-500">
+              <p className="text-xs text-gray-500 dark:text-gray-400">
                 任意の画像ファイルを選択できます
               </p>
             </div>

--- a/image-folder-viewer/src/components/cards/CardGrid.tsx
+++ b/image-folder-viewer/src/components/cards/CardGrid.tsx
@@ -85,7 +85,7 @@ export const CardGrid = ({
 
   if (cards.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center h-64 text-gray-400">
+      <div className="flex flex-col items-center justify-center h-64 text-gray-400 dark:text-gray-500">
         <p className="text-lg">カードがありません</p>
         <p className="text-sm mt-2">Ctrl+N でカードを追加できます</p>
       </div>

--- a/image-folder-viewer/src/components/cards/CardItem.tsx
+++ b/image-folder-viewer/src/components/cards/CardItem.tsx
@@ -89,7 +89,7 @@ export const CardItem = ({
 
   // スタイルクラス
   const containerClasses = [
-    "group relative flex flex-col rounded-lg overflow-hidden bg-white shadow transition-all",
+    "group relative flex flex-col rounded-lg overflow-hidden bg-white dark:bg-gray-800 shadow transition-all",
     isSelected ? "ring-2 ring-blue-500" : "",
     isValid ? "cursor-pointer hover:shadow-lg" : "cursor-not-allowed",
     !isValid ? "ring-2 ring-red-400" : "",
@@ -106,11 +106,11 @@ export const CardItem = ({
       {...dragHandleProps}
     >
       {/* サムネイル領域 */}
-      <div className="relative aspect-square bg-gray-100 flex items-center justify-center overflow-hidden">
+      <div className="relative aspect-square bg-gray-100 dark:bg-gray-700 flex items-center justify-center overflow-hidden">
         {isValid ? (
           isLoadingThumbnail ? (
             // ローディング
-            <div className="animate-pulse bg-gray-200 w-full h-full" />
+            <div className="animate-pulse bg-gray-200 dark:bg-gray-600 w-full h-full" />
           ) : thumbnailUrl ? (
             // サムネイル画像
             <img
@@ -120,7 +120,7 @@ export const CardItem = ({
             />
           ) : (
             // 画像なし
-            <ImageIcon size={48} className="text-gray-300" />
+            <ImageIcon size={48} className="text-gray-300 dark:text-gray-600" />
           )
         ) : (
           // エラー状態
@@ -132,10 +132,10 @@ export const CardItem = ({
       </div>
 
       {/* タイトル・操作ボタン領域 */}
-      <div className="p-2 border-t border-gray-100">
+      <div className="p-2 border-t border-gray-100 dark:border-gray-700">
         <div className="flex items-center justify-between gap-2">
           {/* タイトル */}
-          <span className="text-sm font-medium text-gray-700 truncate flex-1">
+          <span className="text-sm font-medium text-gray-700 dark:text-gray-300 truncate flex-1">
             {card.title}
           </span>
 
@@ -144,7 +144,7 @@ export const CardItem = ({
             <button
               type="button"
               onClick={handleEdit}
-              className="p-1 text-gray-400 hover:text-blue-600 hover:bg-blue-50 rounded transition-colors"
+              className="p-1 text-gray-400 hover:text-blue-600 hover:bg-blue-50 dark:text-gray-500 dark:hover:text-blue-400 dark:hover:bg-blue-900 rounded transition-colors"
               title="編集"
             >
               <Pencil size={16} />
@@ -152,7 +152,7 @@ export const CardItem = ({
             <button
               type="button"
               onClick={handleDelete}
-              className="p-1 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded transition-colors"
+              className="p-1 text-gray-400 hover:text-red-600 hover:bg-red-50 dark:text-gray-500 dark:hover:text-red-400 dark:hover:bg-red-900 rounded transition-colors"
               title="削除"
             >
               <Trash2 size={16} />

--- a/image-folder-viewer/src/components/common/ConfirmModal.tsx
+++ b/image-folder-viewer/src/components/common/ConfirmModal.tsx
@@ -46,7 +46,7 @@ export const ConfirmModal = ({
         </>
       }
     >
-      <p className="text-gray-700">{message}</p>
+      <p className="text-gray-700 dark:text-gray-300">{message}</p>
     </Modal>
   );
 };

--- a/image-folder-viewer/src/components/common/ContextMenu.tsx
+++ b/image-folder-viewer/src/components/common/ContextMenu.tsx
@@ -73,21 +73,21 @@ export function ContextMenu({ items, x, y, onClose }: ContextMenuProps) {
     <div className="fixed inset-0 z-50" onClick={handleOverlayClick}>
       <div
         ref={menuRef}
-        className="absolute bg-gray-800 border border-gray-600 rounded-lg shadow-xl py-1 min-w-[180px]"
+        className="absolute bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded-lg shadow-xl py-1 min-w-[180px]"
         style={{ left: x, top: y }}
       >
         {items.map((item, index) => (
           <div key={index}>
             {item.separator && (
-              <div className="border-t border-gray-600 my-1" />
+              <div className="border-t border-gray-200 dark:border-gray-600 my-1" />
             )}
             <button
-              className="w-full text-left px-4 py-1.5 text-sm text-gray-200 hover:bg-gray-700 flex justify-between items-center"
+              className="w-full text-left px-4 py-1.5 text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-700 flex justify-between items-center"
               onClick={() => handleItemClick(item)}
             >
               <span>{item.label}</span>
               {item.shortcut && (
-                <span className="text-gray-500 text-xs ml-4">
+                <span className="text-gray-400 dark:text-gray-500 text-xs ml-4">
                   {item.shortcut}
                 </span>
               )}

--- a/image-folder-viewer/src/components/common/Modal.tsx
+++ b/image-folder-viewer/src/components/common/Modal.tsx
@@ -76,20 +76,20 @@ export const Modal = ({
       onClick={handleOverlayClick}
     >
       <div
-        className={`${widthClasses[width]} w-full mx-4 bg-white rounded-lg shadow-xl`}
+        className={`${widthClasses[width]} w-full mx-4 bg-white dark:bg-gray-800 rounded-lg shadow-xl`}
         role="dialog"
         aria-modal="true"
         aria-labelledby="modal-title"
       >
         {/* ヘッダー */}
-        <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200">
-          <h2 id="modal-title" className="text-lg font-semibold text-gray-900">
+        <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200 dark:border-gray-700">
+          <h2 id="modal-title" className="text-lg font-semibold text-gray-900 dark:text-gray-100">
             {title}
           </h2>
           <button
             type="button"
             onClick={onClose}
-            className="p-1 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded transition-colors"
+            className="p-1 text-gray-400 hover:text-gray-600 hover:bg-gray-100 dark:text-gray-500 dark:hover:text-gray-300 dark:hover:bg-gray-700 rounded transition-colors"
             aria-label="閉じる"
           >
             <X size={20} />
@@ -101,7 +101,7 @@ export const Modal = ({
 
         {/* フッター */}
         {footer && (
-          <div className="px-4 py-3 border-t border-gray-200 flex justify-end gap-2">
+          <div className="px-4 py-3 border-t border-gray-200 dark:border-gray-700 flex justify-end gap-2">
             {footer}
           </div>
         )}
@@ -123,7 +123,7 @@ interface ButtonProps {
 const variantClasses = {
   primary: "bg-blue-600 text-white hover:bg-blue-700 disabled:bg-blue-300",
   secondary:
-    "bg-gray-100 text-gray-700 hover:bg-gray-200 disabled:bg-gray-50 disabled:text-gray-400",
+    "bg-gray-100 text-gray-700 hover:bg-gray-200 disabled:bg-gray-50 disabled:text-gray-400 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600 dark:disabled:bg-gray-800 dark:disabled:text-gray-500",
   danger: "bg-red-600 text-white hover:bg-red-700 disabled:bg-red-300",
 };
 

--- a/image-folder-viewer/src/index.css
+++ b/image-folder-viewer/src/index.css
@@ -1,1 +1,2 @@
 @import "tailwindcss";
+@custom-variant dark (&:where(.dark, .dark *));

--- a/image-folder-viewer/src/pages/IndexPage.tsx
+++ b/image-folder-viewer/src/pages/IndexPage.tsx
@@ -340,9 +340,9 @@ export function IndexPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-100">
+    <div className="min-h-screen bg-gray-100 dark:bg-gray-900">
       {/* ヘッダー */}
-      <header className="bg-white shadow">
+      <header className="bg-white dark:bg-gray-800 shadow">
         <div className="max-w-7xl mx-auto px-4 py-3 flex items-center justify-between">
           <div className="flex items-center space-x-4">
             <ProfileSelector />
@@ -362,12 +362,12 @@ export function IndexPage() {
       {/* エラー表示 */}
       {error && (
         <div className="max-w-7xl mx-auto px-4 py-2">
-          <div className="p-3 bg-red-50 border border-red-200 rounded-lg">
+          <div className="p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg">
             <div className="flex items-start justify-between">
-              <p className="text-red-700 text-sm">{error}</p>
+              <p className="text-red-700 dark:text-red-400 text-sm">{error}</p>
               <button
                 onClick={clearError}
-                className="text-red-500 hover:text-red-700 ml-2"
+                className="text-red-500 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300 ml-2"
               >
                 ×
               </button>

--- a/image-folder-viewer/src/pages/ViewerPage.tsx
+++ b/image-folder-viewer/src/pages/ViewerPage.tsx
@@ -511,21 +511,21 @@ export function ViewerPage() {
   }
 
   return (
-    <div className="h-screen bg-black flex flex-col" onContextMenu={handleContextMenu}>
+    <div className="h-screen bg-white dark:bg-black flex flex-col" onContextMenu={handleContextMenu}>
       {/* タイトルバー */}
-      <header className="bg-gray-900 text-white px-4 py-2 flex items-center justify-between shrink-0">
+      <header className="bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-white px-4 py-2 flex items-center justify-between shrink-0">
         <div className="flex items-center space-x-4 min-w-0">
           <button
             onClick={handleBack}
-            className="flex items-center gap-1 px-3 py-1 bg-gray-700 rounded hover:bg-gray-600 transition shrink-0"
+            className="flex items-center gap-1 px-3 py-1 bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 rounded transition shrink-0"
           >
             <ArrowLeft size={16} />
             戻る
           </button>
-          <span className="text-sm text-gray-300 truncate">
+          <span className="text-sm text-gray-600 dark:text-gray-300 truncate">
             {card.title}
             {currentImage && (
-              <span className="text-gray-500">
+              <span className="text-gray-400 dark:text-gray-500">
                 {" - "}
                 {currentImage.filename}
               </span>
@@ -533,7 +533,7 @@ export function ViewerPage() {
           </span>
         </div>
         <div className="flex items-center space-x-2 shrink-0">
-          <span className="text-xs text-yellow-400 font-mono">
+          <span className="text-xs text-yellow-600 dark:text-yellow-400 font-mono">
             {Math.round(zoomLevel * 100)}%
           </span>
           <button
@@ -541,7 +541,7 @@ export function ViewerPage() {
             className={`text-xs px-2 py-0.5 rounded transition ${
               hFlipEnabled
                 ? "bg-blue-600 text-white"
-                : "bg-gray-700 text-gray-400 hover:bg-gray-600"
+                : "bg-gray-200 text-gray-500 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600"
             }`}
             title="水平反転 (H)"
           >
@@ -552,7 +552,7 @@ export function ViewerPage() {
             className={`text-xs px-2 py-0.5 rounded transition ${
               shuffleEnabled
                 ? "bg-blue-600 text-white"
-                : "bg-gray-700 text-gray-400 hover:bg-gray-600"
+                : "bg-gray-200 text-gray-500 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600"
             }`}
             title="シャッフル (R)"
           >
@@ -569,10 +569,10 @@ export function ViewerPage() {
 
         {error && (
           <div className="text-center">
-            <div className="text-red-400 text-lg mb-2">{error}</div>
+            <div className="text-red-500 dark:text-red-400 text-lg mb-2">{error}</div>
             <button
               onClick={handleBack}
-              className="text-gray-400 hover:text-white text-sm underline"
+              className="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white text-sm underline"
             >
               インデックスに戻る
             </button>
@@ -593,12 +593,12 @@ export function ViewerPage() {
 
       {/* フッター（ナビゲーション情報） */}
       {totalImages > 0 && (
-        <footer className="bg-gray-900 text-gray-400 px-4 py-1.5 text-xs flex justify-between shrink-0">
+        <footer className="bg-gray-100 dark:bg-gray-900 text-gray-500 dark:text-gray-400 px-4 py-1.5 text-xs flex justify-between shrink-0">
           <span>
             {(shuffleEnabled ? currentIndex : actualIndex) + 1} / {totalImages}
             {shuffleEnabled && " (シャッフル)"}
           </span>
-          <span className="text-gray-600">
+          <span className="text-gray-400 dark:text-gray-600">
             ←→: ナビゲーション | H: 反転 | R: シャッフル | +/-: ズーム | Space: メニュー |
             ESC: 戻る
           </span>

--- a/image-folder-viewer/src/store/profileStore.ts
+++ b/image-folder-viewer/src/store/profileStore.ts
@@ -3,6 +3,7 @@
 import { create } from "zustand";
 import { useShallow } from "zustand/react/shallow";
 import type { ProfileData, AppConfig, RecentProfile, Card, AppState } from "../types";
+import { applyTheme, type Theme } from "../utils/theme";
 import {
   loadProfile,
   saveProfile,
@@ -103,6 +104,8 @@ export const useProfileStore = create<ProfileState & ProfileActions>(
       try {
         const initialState = await getInitialState();
 
+        applyTheme((initialState.appConfig.theme ?? "dark") as Theme);
+
         if (initialState.profile && initialState.profilePath) {
           // プロファイルが先読み済み: そのまま設定して直接 IndexPage へ
           set({
@@ -138,6 +141,7 @@ export const useProfileStore = create<ProfileState & ProfileActions>(
         const profile = await loadProfile(path);
         await addRecentProfile(path);
         const config = await getAppConfig();
+        applyTheme((config.theme ?? "dark") as Theme);
         set({
           currentProfile: profile,
           currentProfilePath: path,

--- a/image-folder-viewer/src/types/index.ts
+++ b/image-folder-viewer/src/types/index.ts
@@ -73,7 +73,7 @@ export interface AppConfig {
   version: string;
   recentProfiles: RecentProfile[];
   maxRecentProfiles: number;
-  theme: "light" | "dark" | "system";
+  theme: "light" | "dark";
   /** 起動時にウィンドウを最前面に表示する（Linux のフォーカス盗み防止対策、デフォルト: true） */
   focusOnStartup: boolean;
 }

--- a/image-folder-viewer/src/utils/theme.ts
+++ b/image-folder-viewer/src/utils/theme.ts
@@ -1,0 +1,7 @@
+// カラーテーマ適用ユーティリティ
+
+export type Theme = "light" | "dark";
+
+export function applyTheme(theme: Theme) {
+  document.documentElement.classList.toggle("dark", theme === "dark");
+}


### PR DESCRIPTION
## Summary

- Tailwind v4 クラスベースダークモード（`@custom-variant dark`）を設定
- `src/utils/theme.ts` を新規作成し、`applyTheme("light" | "dark")` で `<html>` の `.dark` クラスを制御
- `profileStore` の `initialize()` / `openProfile()` で `applyTheme()` を呼び出し、起動時・プロファイル切り替え時にテーマを適用
- 全ページ・コンポーネントに `dark:` クラスを追加（IndexPage, ViewerPage, Modal, ContextMenu, Card系など）
- `system` テーマを廃止（Tauri WebKit WebView では `matchMedia` の change イベントが発火しないため）、テーマ設定は `"light"` / `"dark"` の2択に変更

## Test plan

- [ ] `app_config.json` の `theme` を `"dark"` に設定して起動 → 全ページがダーク配色になることを確認
- [ ] `theme` を `"light"` に設定 → 全ページがライト配色になることを確認
- [ ] アプリ再起動後もテーマが復元されることを確認

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)