### PR TITLE
feat: カードサムネイル比率切替機能の実装 (#28)

### DIFF
--- a/image-folder-viewer/src-tauri/src/models/app_config.rs
+++ b/image-folder-viewer/src-tauri/src/models/app_config.rs
@@ -14,6 +14,9 @@ fn default_theme() -> String {
 fn default_true() -> bool {
     true
 }
+fn default_thumbnail_aspect_ratio() -> String {
+    "16:9".to_string()
+}
 
 /// 最近使用したプロファイル
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -47,6 +50,9 @@ pub struct AppConfig {
     /// 起動時にウィンドウを最前面に表示する（Linux のフォーカス盗み防止対策）
     #[serde(default = "default_true")]
     pub focus_on_startup: bool,
+    /// サムネイルのアスペクト比 ("16:9" | "4:3" | "1:1")
+    #[serde(default = "default_thumbnail_aspect_ratio")]
+    pub thumbnail_aspect_ratio: String,
 }
 
 impl Default for AppConfig {
@@ -57,6 +63,7 @@ impl Default for AppConfig {
             max_recent_profiles: default_max_recent_profiles(),
             theme: default_theme(),
             focus_on_startup: default_true(),
+            thumbnail_aspect_ratio: default_thumbnail_aspect_ratio(),
         }
     }
 }

--- a/image-folder-viewer/src/components/cards/CardGrid.tsx
+++ b/image-folder-viewer/src/components/cards/CardGrid.tsx
@@ -16,7 +16,15 @@ import {
   rectSortingStrategy,
 } from "@dnd-kit/sortable";
 import { SortableCardItem } from "./SortableCardItem";
-import type { Card } from "../../types";
+import type { Card, ThumbnailAspectRatio } from "../../types";
+
+// アスペクト比ごとのカード幅（固定値）
+// 16:9=480x270, 4:3=360x270, 1:1=270x270
+const GRID_CARD_WIDTH: Record<ThumbnailAspectRatio, number> = {
+  "16:9": 480,
+  "4:3": 360,
+  "1:1": 270,
+};
 
 // カードの有効性情報
 export interface CardValidation {
@@ -29,6 +37,7 @@ interface CardGridProps {
   cards: Card[];
   validations: Map<string, CardValidation>;
   selectedCardId: string | null;
+  aspectRatio?: ThumbnailAspectRatio;
   onCardClick: (card: Card) => void;
   onCardEdit: (card: Card) => void;
   onCardDelete: (card: Card) => void;
@@ -39,6 +48,7 @@ export const CardGrid = ({
   cards,
   validations,
   selectedCardId,
+  aspectRatio,
   onCardClick,
   onCardEdit,
   onCardDelete,
@@ -99,7 +109,10 @@ export const CardGrid = ({
       onDragEnd={handleDragEnd}
     >
       <SortableContext items={cardIds} strategy={rectSortingStrategy}>
-        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4 p-4">
+        <div
+          className="grid gap-4 p-4"
+          style={{ gridTemplateColumns: `repeat(auto-fill, ${GRID_CARD_WIDTH[aspectRatio ?? "16:9"]}px)` }}
+        >
           {cards.map((card) => {
             const validation = validations.get(card.id);
             const isValid = validation?.isValid ?? true;
@@ -112,6 +125,7 @@ export const CardGrid = ({
                 isValid={isValid}
                 errorMessage={errorMessage}
                 isSelected={card.id === selectedCardId}
+                aspectRatio={aspectRatio}
                 onClick={() => onCardClick(card)}
                 onEdit={() => onCardEdit(card)}
                 onDelete={() => onCardDelete(card)}

--- a/image-folder-viewer/src/components/cards/CardItem.tsx
+++ b/image-folder-viewer/src/components/cards/CardItem.tsx
@@ -3,13 +3,14 @@
 import { useState, useEffect } from "react";
 import { Pencil, Trash2, AlertTriangle, ImageIcon } from "lucide-react";
 import { getThumbnail } from "../../api/tauri";
-import type { Card } from "../../types";
+import type { Card, ThumbnailAspectRatio } from "../../types";
 
 interface CardItemProps {
   card: Card;
   isValid: boolean;
   errorMessage?: string;
   isSelected?: boolean;
+  aspectRatio?: ThumbnailAspectRatio;
   onClick?: () => void;
   onEdit?: () => void;
   onDelete?: () => void;
@@ -18,14 +19,26 @@ interface CardItemProps {
   isDragging?: boolean;
 }
 
-// サムネイルサイズ
-const THUMBNAIL_SIZE = 200;
+// アスペクト比ごとのサムネイルサイズ（長辺基準）
+const THUMBNAIL_SIZES: Record<ThumbnailAspectRatio, number> = {
+  "16:9": 480,
+  "4:3": 360,
+  "1:1": 270,
+};
+
+// アスペクト比ごとのTailwind CSSクラス
+const ASPECT_RATIO_CLASSES: Record<ThumbnailAspectRatio, string> = {
+  "16:9": "aspect-video",
+  "4:3": "aspect-[4/3]",
+  "1:1": "aspect-square",
+};
 
 export const CardItem = ({
   card,
   isValid,
   errorMessage,
   isSelected = false,
+  aspectRatio = "16:9",
   onClick,
   onEdit,
   onDelete,
@@ -34,6 +47,9 @@ export const CardItem = ({
 }: CardItemProps) => {
   const [thumbnailUrl, setThumbnailUrl] = useState<string | null>(null);
   const [isLoadingThumbnail, setIsLoadingThumbnail] = useState(false);
+
+  const thumbnailSize = THUMBNAIL_SIZES[aspectRatio];
+  const aspectClass = ASPECT_RATIO_CLASSES[aspectRatio];
 
   // サムネイル読み込み
   useEffect(() => {
@@ -45,7 +61,7 @@ export const CardItem = ({
     let cancelled = false;
     setIsLoadingThumbnail(true);
 
-    getThumbnail(card.thumbnail, THUMBNAIL_SIZE)
+    getThumbnail(card.thumbnail, thumbnailSize)
       .then((url) => {
         if (!cancelled) {
           setThumbnailUrl(url);
@@ -66,7 +82,7 @@ export const CardItem = ({
     return () => {
       cancelled = true;
     };
-  }, [card.thumbnail, isValid]);
+  }, [card.thumbnail, isValid, thumbnailSize]);
 
   // カードクリック
   const handleClick = () => {
@@ -106,7 +122,7 @@ export const CardItem = ({
       {...dragHandleProps}
     >
       {/* サムネイル領域 */}
-      <div className="relative aspect-square bg-gray-100 dark:bg-gray-700 flex items-center justify-center overflow-hidden">
+      <div className={`relative ${aspectClass} bg-gray-100 dark:bg-gray-700 flex items-center justify-center overflow-hidden`}>
         {isValid ? (
           isLoadingThumbnail ? (
             // ローディング

--- a/image-folder-viewer/src/components/cards/SortableCardItem.tsx
+++ b/image-folder-viewer/src/components/cards/SortableCardItem.tsx
@@ -3,13 +3,14 @@
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { CardItem } from "./CardItem";
-import type { Card } from "../../types";
+import type { Card, ThumbnailAspectRatio } from "../../types";
 
 interface SortableCardItemProps {
   card: Card;
   isValid: boolean;
   errorMessage?: string;
   isSelected?: boolean;
+  aspectRatio?: ThumbnailAspectRatio;
   onClick?: () => void;
   onEdit?: () => void;
   onDelete?: () => void;
@@ -20,6 +21,7 @@ export const SortableCardItem = ({
   isValid,
   errorMessage,
   isSelected,
+  aspectRatio,
   onClick,
   onEdit,
   onDelete,
@@ -46,6 +48,7 @@ export const SortableCardItem = ({
         isValid={isValid}
         errorMessage={errorMessage}
         isSelected={isSelected}
+        aspectRatio={aspectRatio}
         onClick={onClick}
         onEdit={onEdit}
         onDelete={onDelete}

--- a/image-folder-viewer/src/pages/IndexPage.tsx
+++ b/image-folder-viewer/src/pages/IndexPage.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useCallback, useMemo, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { Plus } from "lucide-react";
+import type { ThumbnailAspectRatio } from "../types";
 import { ProfileSelector } from "../components/profile/ProfileSelector";
 import { CardGrid, type CardValidation } from "../components/cards/CardGrid";
 import { CardAddModal } from "../components/cards/CardAddModal";
@@ -16,6 +17,7 @@ import {
   type AddCardInput,
   type UpdateCardInput,
 } from "../store/profileStore";
+import { useShallow } from "zustand/react/shallow";
 import { validateFolderPath } from "../api/tauri";
 import { getCurrentWindow, LogicalPosition, LogicalSize, currentMonitor } from "@tauri-apps/api/window";
 import type { Card } from "../types";
@@ -30,7 +32,12 @@ export function IndexPage() {
     initialize,
     initialized,
     isAutoOpening,
+    updateThumbnailAspectRatio,
   } = useProfileStore();
+
+  const thumbnailAspectRatio = useProfileStore(
+    useShallow((state) => (state.appConfig?.thumbnailAspectRatio ?? "16:9") as ThumbnailAspectRatio)
+  );
   const cards = useCards();
   const { addCard, updateCard, deleteCard, reorderCards } = useCardActions();
   const updateAppState = useProfileStore((state) => state.updateAppState);
@@ -348,6 +355,24 @@ export function IndexPage() {
             <ProfileSelector />
           </div>
           <div className="flex items-center space-x-2">
+            {/* サムネイル比率切替 */}
+            <div className="flex rounded border border-gray-300 dark:border-gray-600 overflow-hidden text-xs">
+              {(["16:9", "4:3", "1:1"] as ThumbnailAspectRatio[]).map((ratio) => (
+                <button
+                  key={ratio}
+                  type="button"
+                  onClick={() => updateThumbnailAspectRatio(ratio)}
+                  className={[
+                    "px-2 py-1 transition-colors",
+                    thumbnailAspectRatio === ratio
+                      ? "bg-blue-600 text-white"
+                      : "bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-600",
+                  ].join(" ")}
+                >
+                  {ratio}
+                </button>
+              ))}
+            </div>
             <button
               className="flex items-center gap-1 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition"
               onClick={() => setIsAddModalOpen(true)}
@@ -377,11 +402,12 @@ export function IndexPage() {
       )}
 
       {/* カードグリッド */}
-      <main className="max-w-7xl mx-auto">
+      <main className="w-full">
         <CardGrid
           cards={cards}
           validations={validations}
           selectedCardId={selectedCardId}
+          aspectRatio={thumbnailAspectRatio}
           onCardClick={handleCardClick}
           onCardEdit={handleCardEdit}
           onCardDelete={handleCardDelete}

--- a/image-folder-viewer/src/store/profileStore.ts
+++ b/image-folder-viewer/src/store/profileStore.ts
@@ -2,13 +2,14 @@
 
 import { create } from "zustand";
 import { useShallow } from "zustand/react/shallow";
-import type { ProfileData, AppConfig, RecentProfile, Card, AppState } from "../types";
+import type { ProfileData, AppConfig, RecentProfile, Card, AppState, ThumbnailAspectRatio } from "../types";
 import { applyTheme, type Theme } from "../utils/theme";
 import {
   loadProfile,
   saveProfile,
   createNewProfile,
   getAppConfig,
+  saveAppConfig,
   getInitialState,
   addRecentProfile,
   removeRecentProfile,
@@ -75,6 +76,9 @@ interface ProfileActions {
 
   // appState更新
   updateAppState: (partial: Partial<AppState>) => void;
+
+  // サムネイル比率変更
+  updateThumbnailAspectRatio: (ratio: ThumbnailAspectRatio) => Promise<void>;
 
   // 履歴操作
   removeFromHistory: (path: string) => Promise<void>;
@@ -419,6 +423,15 @@ export const useProfileStore = create<ProfileState & ProfileActions>(
           updatedAt: now,
         },
       });
+    },
+
+    // サムネイル比率を変更して保存
+    updateThumbnailAspectRatio: async (ratio: ThumbnailAspectRatio) => {
+      const { appConfig } = get();
+      if (!appConfig) return;
+      const newConfig = { ...appConfig, thumbnailAspectRatio: ratio };
+      await saveAppConfig(newConfig);
+      set({ appConfig: newConfig });
     },
 
     // 履歴から削除

--- a/image-folder-viewer/src/types/index.ts
+++ b/image-folder-viewer/src/types/index.ts
@@ -68,6 +68,9 @@ export interface RecentProfile {
   lastOpenedAt: string;
 }
 
+// サムネイルのアスペクト比
+export type ThumbnailAspectRatio = "16:9" | "4:3" | "1:1";
+
 // アプリ共通設定
 export interface AppConfig {
   version: string;
@@ -76,6 +79,8 @@ export interface AppConfig {
   theme: "light" | "dark";
   /** 起動時にウィンドウを最前面に表示する（Linux のフォーカス盗み防止対策、デフォルト: true） */
   focusOnStartup: boolean;
+  /** サムネイルのアスペクト比（デフォルト: "16:9"） */
+  thumbnailAspectRatio: ThumbnailAspectRatio;
 }
 
 // 起動時初期状態（get_initial_state コマンドの戻り値）


### PR DESCRIPTION
## Summary

- サムネイル比率を 16:9 / 4:3 / 1:1 の3種類から切り替え可能にする
- 選択した比率は `app_config.json` の `thumbnailAspectRatio` に保存・復元される
- IndexPage ヘッダーに切替ボタンを追加
- カード幅を固定（16:9=480px、4:3=360px、1:1=270px）にし、ウィンドウ幅に応じて列数が変化する

## Changes

- `app_config.rs`: `thumbnailAspectRatio` フィールド追加（デフォルト `"16:9"`）
- `types/index.ts`: `ThumbnailAspectRatio` 型追加
- `profileStore.ts`: `updateThumbnailAspectRatio()` アクション追加
- `CardGrid.tsx`: `aspectRatio` prop 対応、グリッド幅を `minmax(Xpx, 1fr)` → 固定 `Xpx` に変更
- `CardItem.tsx` / `SortableCardItem.tsx`: `aspectRatio` prop に応じてカード高さを変更
- `IndexPage.tsx`: 比率切替ボタン追加、`max-w-7xl` 制限を `w-full` に変更してグリッドの列数制限を解除

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)