### PR TITLE
feat: 設定パネル（歯車アイコン）を追加 (#32)

### DIFF
--- a/image-folder-viewer/src/components/common/SettingsPopover.tsx
+++ b/image-folder-viewer/src/components/common/SettingsPopover.tsx
@@ -1,0 +1,139 @@
+// 設定ポップオーバー（テーマ・サムネイルアスペクト比切替）
+
+import { useEffect, useRef, useCallback } from "react";
+import { createPortal } from "react-dom";
+import { Sun, Moon } from "lucide-react";
+import type { ThumbnailAspectRatio } from "../../types";
+import type { Theme } from "../../utils/theme";
+
+interface SettingsPopoverProps {
+  anchorRef: React.RefObject<HTMLElement | null>;
+  isOpen: boolean;
+  onClose: () => void;
+  theme: Theme;
+  aspectRatio: ThumbnailAspectRatio;
+  onThemeChange: (theme: Theme) => void;
+  onAspectRatioChange: (ratio: ThumbnailAspectRatio) => void;
+}
+
+export function SettingsPopover({
+  anchorRef,
+  isOpen,
+  onClose,
+  theme,
+  aspectRatio,
+  onThemeChange,
+  onAspectRatioChange,
+}: SettingsPopoverProps) {
+  const popoverRef = useRef<HTMLDivElement>(null);
+
+  // Escape で閉じる
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onClose();
+      }
+    },
+    [onClose]
+  );
+
+  useEffect(() => {
+    if (!isOpen) return;
+    window.addEventListener("keydown", handleKeyDown, true);
+    return () => window.removeEventListener("keydown", handleKeyDown, true);
+  }, [isOpen, handleKeyDown]);
+
+  // ポップオーバーの位置をアンカー直下に設定
+  useEffect(() => {
+    if (!isOpen || !anchorRef.current || !popoverRef.current) return;
+
+    const anchor = anchorRef.current.getBoundingClientRect();
+    const popover = popoverRef.current;
+
+    let left = anchor.right - popover.offsetWidth;
+    let top = anchor.bottom + 4;
+
+    // 画面端調整
+    if (left < 4) left = 4;
+    if (top + popover.offsetHeight > window.innerHeight - 4) {
+      top = anchor.top - popover.offsetHeight - 4;
+    }
+
+    popover.style.left = `${left}px`;
+    popover.style.top = `${top}px`;
+  }, [isOpen, anchorRef]);
+
+  if (!isOpen) return null;
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        ref={popoverRef}
+        className="absolute bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded-lg shadow-xl p-4 min-w-[200px]"
+      >
+        {/* テーマ */}
+        <div className="mb-4">
+          <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">テーマ</p>
+          <div className="flex rounded border border-gray-300 dark:border-gray-600 overflow-hidden">
+            <button
+              type="button"
+              onClick={() => onThemeChange("light")}
+              className={[
+                "flex-1 flex items-center justify-center gap-1.5 px-3 py-1.5 text-sm transition-colors",
+                theme === "light"
+                  ? "bg-blue-600 text-white"
+                  : "bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-600",
+              ].join(" ")}
+            >
+              <Sun size={14} />
+              ライト
+            </button>
+            <button
+              type="button"
+              onClick={() => onThemeChange("dark")}
+              className={[
+                "flex-1 flex items-center justify-center gap-1.5 px-3 py-1.5 text-sm transition-colors border-l border-gray-300 dark:border-gray-600",
+                theme === "dark"
+                  ? "bg-blue-600 text-white"
+                  : "bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-600",
+              ].join(" ")}
+            >
+              <Moon size={14} />
+              ダーク
+            </button>
+          </div>
+        </div>
+
+        {/* サムネイルアスペクト比 */}
+        <div>
+          <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">サムネイル比率</p>
+          <div className="flex rounded border border-gray-300 dark:border-gray-600 overflow-hidden text-sm">
+            {(["16:9", "4:3", "1:1"] as ThumbnailAspectRatio[]).map((ratio) => (
+              <button
+                key={ratio}
+                type="button"
+                onClick={() => onAspectRatioChange(ratio)}
+                className={[
+                  "flex-1 px-2 py-1.5 transition-colors",
+                  ratio !== "16:9" ? "border-l border-gray-300 dark:border-gray-600" : "",
+                  aspectRatio === ratio
+                    ? "bg-blue-600 text-white"
+                    : "bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-600",
+                ].join(" ")}
+              >
+                {ratio}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/image-folder-viewer/src/pages/IndexPage.tsx
+++ b/image-folder-viewer/src/pages/IndexPage.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useCallback, useMemo, useRef } from "react";
 import { useNavigate } from "react-router-dom";
-import { Plus } from "lucide-react";
+import { Plus, Settings } from "lucide-react";
 import type { ThumbnailAspectRatio } from "../types";
 import { ProfileSelector } from "../components/profile/ProfileSelector";
 import { CardGrid, type CardValidation } from "../components/cards/CardGrid";
@@ -10,6 +10,8 @@ import { CardAddModal } from "../components/cards/CardAddModal";
 import { CardEditModal } from "../components/cards/CardEditModal";
 import { Spinner } from "../components/common/Spinner";
 import { ConfirmModal } from "../components/common/ConfirmModal";
+import { SettingsPopover } from "../components/common/SettingsPopover";
+import type { Theme } from "../utils/theme";
 import {
   useProfileStore,
   useCards,
@@ -33,10 +35,14 @@ export function IndexPage() {
     initialized,
     isAutoOpening,
     updateThumbnailAspectRatio,
+    updateTheme,
   } = useProfileStore();
 
   const thumbnailAspectRatio = useProfileStore(
     useShallow((state) => (state.appConfig?.thumbnailAspectRatio ?? "16:9") as ThumbnailAspectRatio)
+  );
+  const currentTheme = useProfileStore(
+    (state) => (state.appConfig?.theme ?? "dark") as Theme
   );
   const cards = useCards();
   const { addCard, updateCard, deleteCard, reorderCards } = useCardActions();
@@ -44,6 +50,10 @@ export function IndexPage() {
 
   // 状態復元フラグ（一度だけ実行）
   const restoredRef = useRef(false);
+
+  // 設定パネル
+  const [isSettingsOpen, setIsSettingsOpen] = useState(false);
+  const settingsButtonRef = useRef<HTMLButtonElement>(null);
 
   // 起動時の初期化（前回プロファイルの自動オープンを含む）
   useEffect(() => {
@@ -355,24 +365,16 @@ export function IndexPage() {
             <ProfileSelector />
           </div>
           <div className="flex items-center space-x-2">
-            {/* サムネイル比率切替 */}
-            <div className="flex rounded border border-gray-300 dark:border-gray-600 overflow-hidden text-xs">
-              {(["16:9", "4:3", "1:1"] as ThumbnailAspectRatio[]).map((ratio) => (
-                <button
-                  key={ratio}
-                  type="button"
-                  onClick={() => updateThumbnailAspectRatio(ratio)}
-                  className={[
-                    "px-2 py-1 transition-colors",
-                    thumbnailAspectRatio === ratio
-                      ? "bg-blue-600 text-white"
-                      : "bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-600",
-                  ].join(" ")}
-                >
-                  {ratio}
-                </button>
-              ))}
-            </div>
+            {/* 設定ボタン */}
+            <button
+              ref={settingsButtonRef}
+              type="button"
+              onClick={() => setIsSettingsOpen((v) => !v)}
+              className="p-2 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition-colors"
+              title="設定"
+            >
+              <Settings size={20} />
+            </button>
             <button
               className="flex items-center gap-1 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition"
               onClick={() => setIsAddModalOpen(true)}
@@ -439,6 +441,15 @@ export function IndexPage() {
         title="カードの削除"
         message={`「${deletingCard?.title}」を削除しますか？`}
         confirmLabel="削除"
+      />
+      <SettingsPopover
+        anchorRef={settingsButtonRef}
+        isOpen={isSettingsOpen}
+        onClose={() => setIsSettingsOpen(false)}
+        theme={currentTheme}
+        aspectRatio={thumbnailAspectRatio}
+        onThemeChange={updateTheme}
+        onAspectRatioChange={updateThumbnailAspectRatio}
       />
     </div>
   );

--- a/image-folder-viewer/src/store/profileStore.ts
+++ b/image-folder-viewer/src/store/profileStore.ts
@@ -80,6 +80,9 @@ interface ProfileActions {
   // サムネイル比率変更
   updateThumbnailAspectRatio: (ratio: ThumbnailAspectRatio) => Promise<void>;
 
+  // テーマ変更
+  updateTheme: (theme: Theme) => Promise<void>;
+
   // 履歴操作
   removeFromHistory: (path: string) => Promise<void>;
 
@@ -430,6 +433,16 @@ export const useProfileStore = create<ProfileState & ProfileActions>(
       const { appConfig } = get();
       if (!appConfig) return;
       const newConfig = { ...appConfig, thumbnailAspectRatio: ratio };
+      await saveAppConfig(newConfig);
+      set({ appConfig: newConfig });
+    },
+
+    // テーマを変更して保存
+    updateTheme: async (theme: Theme) => {
+      const { appConfig } = get();
+      if (!appConfig) return;
+      const newConfig = { ...appConfig, theme };
+      applyTheme(theme);
       await saveAppConfig(newConfig);
       set({ appConfig: newConfig });
     },


### PR DESCRIPTION
## 概要

IndexPage ヘッダーに歯車アイコンボタンを追加し、設定パネルにテーマ切替とサムネイルアスペクト比切替を統合。既存のアスペクト比切替ボタン群を削除。

Closes #32

## 変更内容

- `profileStore.ts`: `updateTheme` アクションを追加（`applyTheme` + `saveAppConfig` で即時反映・永続化）
- `components/common/SettingsPopover.tsx`: 新規作成
  - 歯車ボタンに紐付いたポップオーバー（`createPortal` + 画面端自動調整）
  - テーマ切替（ライト / ダーク）
  - サムネイル比率切替（16:9 / 4:3 / 1:1）
  - 外側クリック・Escape で閉じる
- `pages/IndexPage.tsx`: アスペクト比ボタン群を削除、歯車ボタン + `SettingsPopover` を追加

## 動作

- 歯車アイコンをクリック → パネルが直下に開く
- ライト/ダーク切替 → 即時反映 + `app_config.json` に保存
- アスペクト比切替 → メモリキャッシュから即時返却（IPC なし）