### PR TITLE
fix: プロファイル切替前に現在の状態を保存 (#20)

### DIFF
--- a/image-folder-viewer/src/components/profile/ProfileSelector.tsx
+++ b/image-folder-viewer/src/components/profile/ProfileSelector.tsx
@@ -19,7 +19,9 @@ export function ProfileSelector() {
     openProfileWithDialog,
     createProfile,
     saveProfileAs,
+    saveCurrentProfile,
     closeProfile,
+    updateAppState,
     isLoading,
   } = useProfileStore();
 
@@ -41,9 +43,16 @@ export function ProfileSelector() {
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, []);
 
+  // 切替前に現在のプロファイルを保存する共通処理
+  const saveBeforeSwitch = async () => {
+    updateAppState({ lastPage: "index" });
+    await saveCurrentProfile();
+  };
+
   // プロファイルを開く（履歴から）
   const handleOpenRecent = async (path: string) => {
     setIsOpen(false);
+    await saveBeforeSwitch();
     try {
       await openProfile(path);
     } catch {
@@ -54,12 +63,14 @@ export function ProfileSelector() {
   // ダイアログでプロファイルを開く
   const handleOpenWithDialog = async () => {
     setIsOpen(false);
+    await saveBeforeSwitch();
     await openProfileWithDialog();
   };
 
   // 新規プロファイル作成
   const handleCreateNew = async () => {
     setIsOpen(false);
+    await saveBeforeSwitch();
     await createProfile();
   };
 


### PR DESCRIPTION
## 概要

`ProfileSelector` でプロファイルを切り替える際、切替前に現在のプロファイルを保存するよう修正。

Closes #20

## 問題

切替前に保存しないと、ViewerPage から IndexPage に戻った後も `lastPage: "viewer"` がディスクに残り、次回そのプロファイルを開いたときに不意に ViewerPage が復元されるケースがあった。

## 変更内容

`ProfileSelector.tsx` に `saveBeforeSwitch()` を追加し、切替前に以下を実行:

1. `updateAppState({ lastPage: "index" })` — ViewerPage から戻った際に残る stale な `"viewer"` 値を確定した `"index"` に上書き
2. `saveCurrentProfile()` — 確定した状態をディスクに保存

対象ハンドラー（3経路）:
- `handleOpenRecent()` — 履歴からプロファイルを開く
- `handleOpenWithDialog()` — ダイアログからプロファイルを開く
- `handleCreateNew()` — 新規プロファイル作成

対象外:
- `handleSaveAs()` — 別名保存（プロファイル切替ではない）
- `handleBackToStartup()` — 起動画面へ戻る（issue スコープ外）