### PR TITLE
feat: ビューアステートをカード単位に移動 (#35)

### DIFF
--- a/image-folder-viewer/src-tauri/src/models/profile.rs
+++ b/image-folder-viewer/src-tauri/src/models/profile.rs
@@ -2,6 +2,20 @@
 
 use serde::{Deserialize, Serialize};
 
+/// カード固有のビューア状態
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CardViewerState {
+    #[serde(default)]
+    pub last_image_index: i32,
+    #[serde(default)]
+    pub last_image_filename: Option<String>,
+    #[serde(default)]
+    pub h_flip_enabled: bool,
+    #[serde(default)]
+    pub shuffle_enabled: bool,
+}
+
 /// カード情報
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -16,6 +30,9 @@ pub struct Card {
     /// サブディレクトリを含めて画像を検索するか（省略時 false、既存プロファイルとの後方互換）
     #[serde(default)]
     pub recursive: bool,
+    /// カード固有のビューア状態（省略時 None、既存プロファイルとの後方互換）
+    #[serde(default)]
+    pub viewer_state: Option<CardViewerState>,
 }
 
 /// カード（検証結果付き）

--- a/image-folder-viewer/src/pages/ViewerPage.tsx
+++ b/image-folder-viewer/src/pages/ViewerPage.tsx
@@ -36,6 +36,7 @@ export function ViewerPage() {
   // プロファイルからカード情報を取得
   const currentProfile = useProfileStore((state) => state.currentProfile);
   const updateAppState = useProfileStore((state) => state.updateAppState);
+  const updateCardViewerState = useProfileStore((state) => state.updateCardViewerState);
   const card = currentProfile?.cards.find((c) => c.id === cardId) ?? null;
 
   // ビューアストア
@@ -253,17 +254,17 @@ export function ViewerPage() {
     };
   }, []);
 
-  // ビューア状態をappStateに保存し、プロファイルをディスクに書き出す
+  // ビューア状態をカード単位で保存し、プロファイルをディスクに書き出す
   const saveViewerState = useCallback(() => {
+    if (!cardId) return;
     const viewerState = useViewerStore.getState();
     // シャッフル時は元のインデックスを保存
     const imageIndex = viewerState.shuffledIndices
       ? viewerState.shuffledIndices[viewerState.currentIndex]
       : viewerState.currentIndex;
 
-    updateAppState({
-      lastPage: "viewer",
-      lastCardId: viewerState.cardId,
+    // カード固有状態 + appState.lastPage/lastCardId を同時更新
+    updateCardViewerState(cardId, {
       lastImageIndex: imageIndex,
       lastImageFilename: viewerState.images[imageIndex]?.filename,
       hFlipEnabled: viewerState.hFlipEnabled,
@@ -278,7 +279,7 @@ export function ViewerPage() {
         addToast(`プロファイルの保存に失敗しました: ${e}`, "error")
       );
     }
-  }, [updateAppState, addToast]);
+  }, [cardId, updateCardViewerState, addToast]);
 
   // 画像表示・オプション変更時にビューア状態を保存
   useEffect(() => {
@@ -312,21 +313,36 @@ export function ViewerPage() {
   useEffect(() => {
     if (!cardId || !folderPath) return;
 
-    // appStateから前回の状態を復元
+    // 復元優先順位:
+    // 1. カード固有のビューア状態（viewerState）があればそれを使用
+    // 2. 後方互換：viewerState未設定 & 起動時復元の場合は appState から読む
+    // 3. それ以外は初期値（index=0, hFlip/shuffle=false）
+    const cardViewerState = card?.viewerState;
     const appState = currentProfile?.appState;
-    const isRestore = appState?.lastPage === "viewer" && appState?.lastCardId === cardId;
+    const isLegacyRestore = !cardViewerState
+      && appState?.lastPage === "viewer"
+      && appState?.lastCardId === cardId;
+
+    const restoreIndex = cardViewerState?.lastImageIndex
+      ?? (isLegacyRestore ? appState!.lastImageIndex : 0);
+    const restoreHFlip = cardViewerState?.hFlipEnabled
+      ?? (isLegacyRestore ? appState!.hFlipEnabled : false);
+    const restoreShuffle = cardViewerState?.shuffleEnabled
+      ?? (isLegacyRestore ? appState!.shuffleEnabled : false);
+    const restoreFilename = cardViewerState?.lastImageFilename
+      ?? (isLegacyRestore ? appState!.lastImageFilename : undefined);
 
     loadImages(
       cardId,
       cardTitle,
       folderPath,
-      isRestore ? appState.lastImageIndex : 0,
-      isRestore ? appState.hFlipEnabled : false,
-      isRestore ? appState.shuffleEnabled : false,
+      restoreIndex,
+      restoreHFlip,
+      restoreShuffle,
       recursive,
-      isRestore ? appState.lastImageFilename : undefined,
+      restoreFilename,
     );
-  }, [cardId, cardTitle, folderPath, recursive, loadImages]); // currentProfileは意図的に依存配列から除外
+  }, [cardId, cardTitle, folderPath, recursive, loadImages]); // currentProfile/cardは意図的に依存配列から除外
 
   // プロファイルが読み込まれていない場合はStartupPageへ
   useEffect(() => {

--- a/image-folder-viewer/src/store/profileStore.ts
+++ b/image-folder-viewer/src/store/profileStore.ts
@@ -2,7 +2,7 @@
 
 import { create } from "zustand";
 import { useShallow } from "zustand/react/shallow";
-import type { ProfileData, AppConfig, RecentProfile, Card, AppState, ThumbnailAspectRatio } from "../types";
+import type { ProfileData, AppConfig, RecentProfile, Card, AppState, CardViewerState, ThumbnailAspectRatio } from "../types";
 import { applyTheme, type Theme } from "../utils/theme";
 import {
   loadProfile,
@@ -76,6 +76,9 @@ interface ProfileActions {
 
   // appState更新
   updateAppState: (partial: Partial<AppState>) => void;
+
+  // カード固有ビューア状態の保存（appState.lastPage/lastCardIdも同時更新）
+  updateCardViewerState: (cardId: string, viewerState: CardViewerState) => void;
 
   // サムネイル比率変更
   updateThumbnailAspectRatio: (ratio: ThumbnailAspectRatio) => Promise<void>;
@@ -424,6 +427,31 @@ export const useProfileStore = create<ProfileState & ProfileActions>(
             ...partial,
           },
           updatedAt: now,
+        },
+      });
+    },
+
+    // カード固有ビューア状態を保存（appState.lastPage/lastCardIdも同時更新）
+    updateCardViewerState: (cardId: string, viewerState: CardViewerState) => {
+      const { currentProfile } = get();
+      if (!currentProfile) return;
+
+      const cardIndex = currentProfile.cards.findIndex((c) => c.id === cardId);
+      if (cardIndex === -1) return;
+
+      const newCards = [...currentProfile.cards];
+      newCards[cardIndex] = { ...newCards[cardIndex], viewerState };
+
+      set({
+        currentProfile: {
+          ...currentProfile,
+          cards: newCards,
+          appState: {
+            ...currentProfile.appState,
+            lastPage: "viewer",
+            lastCardId: cardId,
+          },
+          updatedAt: new Date().toISOString(),
         },
       });
     },

--- a/image-folder-viewer/src/types/index.ts
+++ b/image-folder-viewer/src/types/index.ts
@@ -1,5 +1,13 @@
 // 型定義
 
+// カード固有のビューア状態
+export interface CardViewerState {
+  lastImageIndex: number;
+  lastImageFilename?: string;
+  hFlipEnabled: boolean;
+  shuffleEnabled: boolean;
+}
+
 // カード
 export interface Card {
   id: string;
@@ -11,6 +19,8 @@ export interface Card {
   updatedAt: string;
   /** サブディレクトリを含めて画像を検索するか */
   recursive: boolean;
+  /** カード固有のビューア状態（未設定時は undefined） */
+  viewerState?: CardViewerState;
 }
 
 // カード（検証結果付き）


### PR DESCRIPTION
## Summary

- `CardViewerState`（`lastImageIndex`, `lastImageFilename`, `hFlipEnabled`, `shuffleEnabled`）をプロファイル単位の `AppState` からカード単位の `Card.viewerState` に移動
- 各カードが独立してビューア状態を記憶できるようになった
- 既存プロファイルとの後方互換を保持（`#[serde(default)]` / `viewerState` 未設定時は旧 `appState` からフォールバック読み込み）

## Changes

- **`src-tauri/src/models/profile.rs`**: `CardViewerState` 構造体追加、`Card` に `viewer_state: Option<CardViewerState>` フィールド追加
- **`src/types/index.ts`**: `CardViewerState` インターフェース追加、`Card` に `viewerState?: CardViewerState` 追加
- **`src/store/profileStore.ts`**: `updateCardViewerState(cardId, viewerState)` アクション追加（`appState.lastPage/lastCardId` と `Card.viewerState` を1回の `set()` で同時更新）
- **`src/pages/ViewerPage.tsx`**: 保存は `updateCardViewerState()` に変更、復元は `card.viewerState` 優先・旧 `appState` フォールバック

## Test plan

- [ ] カードAでビューアを開き、途中の画像・hFlip・シャッフル状態にしてインデックスに戻る
- [ ] カードAを再度開くと前回の状態が復元されることを確認
- [ ] カードBを別途開いて状態を変えた後、カードAに戻ると独立して復元されることを確認
- [ ] 旧プロファイル（`viewerState` なし）を開いた場合、起動時復元（`appState` フォールバック）が動作することを確認
- [ ] プロファイルファイルを確認し、`viewerState` フィールドが各カードに保存されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)