### PR TITLE
feat: カスタム画像ピッカーモーダル実装 (#21)

### DIFF
--- a/image-folder-viewer/package-lock.json
+++ b/image-folder-viewer/package-lock.json
@@ -11,6 +11,7 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "@tanstack/react-virtual": "^3.13.21",
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-opener": "^2",
         "lucide-react": "^0.562.0",
@@ -1442,6 +1443,33 @@
       },
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.21",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.21.tgz",
+      "integrity": "sha512-SYXFrmrbPgXBvf+HsOsKhFgqSe4M6B29VHOsX9Jih9TlNkNkDWx0hWMiMLUghMEzyUz772ndzdEeCEBx+3GIZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.13.21"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.13.21",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.21.tgz",
+      "integrity": "sha512-ww+fmLHyCbPSf7JNbWZP3g7wl6SdNo3ah5Aiw+0e9FDErkVHLKprYUrwTm7dF646FtEkN/KkAKPYezxpmvOjxw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tauri-apps/api": {

--- a/image-folder-viewer/package.json
+++ b/image-folder-viewer/package.json
@@ -13,6 +13,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@tanstack/react-virtual": "^3.13.21",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-opener": "^2",
     "lucide-react": "^0.562.0",

--- a/image-folder-viewer/src/components/cards/CardAddModal.tsx
+++ b/image-folder-viewer/src/components/cards/CardAddModal.tsx
@@ -3,9 +3,9 @@
 import { useState, useEffect } from "react";
 import { FolderOpen, ImageIcon, AlertTriangle } from "lucide-react";
 import { Modal, Button } from "../common/Modal";
+import { ImagePickerModal } from "../common/ImagePickerModal";
 import {
   selectFolder,
-  selectImageFile,
   getFirstImageInFolder,
   getThumbnail,
 } from "../../api/tauri";
@@ -40,6 +40,9 @@ export const CardAddModal = ({ isOpen, onClose, onAdd }: CardAddModalProps) => {
   // ローディング状態
   const [isSelectingFolder, setIsSelectingFolder] = useState(false);
   const [isLoadingThumbnail, setIsLoadingThumbnail] = useState(false);
+
+  // 画像ピッカー
+  const [isPickerOpen, setIsPickerOpen] = useState(false);
 
   // エラー状態
   const [error, setError] = useState<string | null>(null);
@@ -128,17 +131,8 @@ export const CardAddModal = ({ isOpen, onClose, onAdd }: CardAddModalProps) => {
 
 
   // サムネイル変更
-  const handleChangeThumbnail = async () => {
-    setError(null);
-    try {
-      const path = await selectImageFile(folderPath);
-      if (path) {
-        setThumbnailPath(path);
-      }
-    } catch (e) {
-      console.error("画像選択エラー:", e);
-      setError(`画像の選択に失敗しました: ${e}`);
-    }
+  const handleChangeThumbnail = () => {
+    setIsPickerOpen(true);
   };
 
   // 作成
@@ -182,6 +176,7 @@ export const CardAddModal = ({ isOpen, onClose, onAdd }: CardAddModalProps) => {
 
   // 情報入力フェーズ
   return (
+    <>
     <Modal
       isOpen={isOpen}
       onClose={onClose}
@@ -283,5 +278,17 @@ export const CardAddModal = ({ isOpen, onClose, onAdd }: CardAddModalProps) => {
         </div>
       </div>
     </Modal>
+
+    <ImagePickerModal
+      isOpen={isPickerOpen}
+      onClose={() => setIsPickerOpen(false)}
+      onSelect={(path) => {
+        setThumbnailPath(path);
+        setIsPickerOpen(false);
+      }}
+      folderPath={folderPath}
+      recursive={recursive}
+    />
+  </>
   );
 };

--- a/image-folder-viewer/src/components/cards/CardEditModal.tsx
+++ b/image-folder-viewer/src/components/cards/CardEditModal.tsx
@@ -3,9 +3,9 @@
 import { useState, useEffect } from "react";
 import { ImageIcon, FolderOpen, AlertTriangle } from "lucide-react";
 import { Modal, Button } from "../common/Modal";
+import { ImagePickerModal } from "../common/ImagePickerModal";
 import {
   selectFolder,
-  selectImageFile,
   getThumbnail,
   getFirstImageInFolder,
 } from "../../api/tauri";
@@ -42,6 +42,9 @@ export const CardEditModal = ({
 
   // ローディング状態
   const [isLoadingThumbnail, setIsLoadingThumbnail] = useState(false);
+
+  // 画像ピッカー
+  const [isPickerOpen, setIsPickerOpen] = useState(false);
 
   // エラー状態
   const [error, setError] = useState<string | null>(null);
@@ -113,17 +116,8 @@ export const CardEditModal = ({
   };
 
   // サムネイル変更
-  const handleChangeThumbnail = async () => {
-    setError(null);
-    try {
-      const path = await selectImageFile(folderPath);
-      if (path) {
-        setThumbnailPath(path);
-      }
-    } catch (e) {
-      console.error("画像選択エラー:", e);
-      setError(`画像の選択に失敗しました: ${e}`);
-    }
+  const handleChangeThumbnail = () => {
+    setIsPickerOpen(true);
   };
 
   // 保存
@@ -156,6 +150,7 @@ export const CardEditModal = ({
   if (!card) return null;
 
   return (
+    <>
     <Modal
       isOpen={isOpen}
       onClose={onClose}
@@ -293,5 +288,17 @@ export const CardEditModal = ({
         </div>
       </div>
     </Modal>
+
+    <ImagePickerModal
+      isOpen={isPickerOpen}
+      onClose={() => setIsPickerOpen(false)}
+      onSelect={(path) => {
+        setThumbnailPath(path);
+        setIsPickerOpen(false);
+      }}
+      folderPath={folderPath}
+      recursive={recursive}
+    />
+    </>
   );
 };

--- a/image-folder-viewer/src/components/common/ImagePickerModal.tsx
+++ b/image-folder-viewer/src/components/common/ImagePickerModal.tsx
@@ -1,0 +1,295 @@
+// カスタム画像ピッカーモーダル（仮想スクロール対応）
+
+import { useState, useEffect, useRef, memo } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { Check, ImageIcon } from "lucide-react";
+import { Modal, Button } from "./Modal";
+import { Spinner } from "./Spinner";
+import { getImagesInFolder } from "../../api/tauri";
+import { fetchThumbnail } from "../../utils/thumbnailCache";
+import type { ImageFile } from "../../types";
+
+export interface ImagePickerModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSelect: (imagePath: string) => void;
+  folderPath: string;
+  recursive?: boolean;
+}
+
+// グリッド列数
+const COLS = 4;
+// セル高さ（サムネイル + ファイル名）
+const CELL_HEIGHT = 152;
+// サムネイルサイズ
+const THUMBNAIL_SIZE = 120;
+
+/**
+ * 逐次サムネイルローダーフック
+ * visiblePaths を 1 件ずつ順番にロードし、各完了後にイベントループへ制御を返す。
+ * resetKey が変わるとキャッシュをクリアして最初からやり直す。
+ */
+function useSequentialLoader(
+  visiblePaths: string[],
+  size: number,
+  resetKey: string
+): Record<string, string | null | undefined> {
+  const [urls, setUrls] = useState<Record<string, string | null>>({});
+  const loadingRef = useRef(false);
+  const processedRef = useRef<Set<string>>(new Set());
+  const visibleRef = useRef<string[]>(visiblePaths);
+
+  // 最新の可視パスを非同期処理から参照できるよう毎レンダーで同期
+  visibleRef.current = visiblePaths;
+
+  // resetKey 変更時（フォルダ変更・モーダル再オープン）に状態リセット
+  useEffect(() => {
+    processedRef.current = new Set();
+    setUrls({});
+  }, [resetKey]);
+
+  useEffect(() => {
+    const processNext = async () => {
+      // 多重起動防止
+      if (loadingRef.current) return;
+
+      // 可視リストから未処理のパスを1件取得
+      const path = visibleRef.current.find(
+        (p) => !processedRef.current.has(p)
+      );
+      if (!path) return;
+
+      loadingRef.current = true;
+      processedRef.current.add(path);
+
+      try {
+        const url = await fetchThumbnail(path, size);
+        setUrls((prev) => ({ ...prev, [path]: url }));
+      } catch {
+        setUrls((prev) => ({ ...prev, [path]: null }));
+      }
+
+      loadingRef.current = false;
+
+      // ブラウザのアイドル時間に次を処理（スクロール中は自動的に停止）
+      // timeout: スクロールし続けても最大 200ms 以内には実行する（thumbnails の表示遅延上限）
+      await new Promise<void>((r) => {
+        if (typeof requestIdleCallback !== "undefined") {
+          requestIdleCallback(() => r(), { timeout: 200 });
+        } else {
+          setTimeout(r, 16);
+        }
+      });
+      processNext();
+    };
+
+    processNext();
+  }, [visiblePaths, resetKey, size]);
+
+  return urls;
+}
+
+// 各サムネイルセルコンポーネント
+interface ThumbnailCellProps {
+  image: ImageFile;
+  isSelected: boolean;
+  onSelect: (path: string) => void;
+  url: string | null | undefined;
+}
+
+const ThumbnailCell = memo(({ image, isSelected, onSelect, url }: ThumbnailCellProps) => {
+  // undefined = 未ロード、null = エラー、string = DataURL
+  const loading = url === undefined;
+
+  return (
+    <div
+      onClick={() => onSelect(image.path)}
+      className={`relative cursor-pointer rounded border-2 overflow-hidden flex flex-col items-center p-1 transition-colors ${
+        isSelected
+          ? "border-blue-500 bg-blue-50 dark:bg-blue-900/30"
+          : "border-transparent hover:border-gray-300 dark:hover:border-gray-500"
+      }`}
+    >
+      {/* サムネイル部分 */}
+      <div
+        className="w-full bg-gray-100 dark:bg-gray-700 rounded overflow-hidden flex items-center justify-center flex-shrink-0"
+        style={{ height: THUMBNAIL_SIZE }}
+      >
+        {loading ? (
+          <div className="animate-pulse bg-gray-200 dark:bg-gray-600 w-full h-full" />
+        ) : url ? (
+          <img
+            src={url}
+            alt={image.filename}
+            className="w-full h-full object-cover"
+          />
+        ) : (
+          <ImageIcon size={32} className="text-gray-300 dark:text-gray-600" />
+        )}
+      </div>
+
+      {/* ファイル名 */}
+      <p className="w-full mt-1 text-xs text-gray-600 dark:text-gray-400 truncate text-center px-1">
+        {image.filename}
+      </p>
+
+      {/* 選択チェックアイコン */}
+      {isSelected && (
+        <div className="absolute top-2 right-2 bg-blue-500 rounded-full p-0.5">
+          <Check size={12} className="text-white" />
+        </div>
+      )}
+    </div>
+  );
+});
+
+export const ImagePickerModal = ({
+  isOpen,
+  onClose,
+  onSelect,
+  folderPath,
+  recursive = false,
+}: ImagePickerModalProps) => {
+  const [images, setImages] = useState<ImageFile[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedPath, setSelectedPath] = useState<string | null>(null);
+
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+
+  // 行数計算
+  const rowCount = Math.ceil(images.length / COLS);
+
+  const virtualizer = useVirtualizer({
+    count: rowCount,
+    getScrollElement: () => scrollContainerRef.current,
+    estimateSize: () => CELL_HEIGHT,
+    overscan: 1,
+  });
+
+  // 現在ビューポートに表示中のパス一覧
+  const visiblePaths = virtualizer.getVirtualItems().flatMap((virtualRow) => {
+    const startIdx = virtualRow.index * COLS;
+    return images.slice(startIdx, startIdx + COLS).map((img) => img.path);
+  });
+
+  // フォルダ変更・モーダル再オープン時にリセットするキー
+  const resetKey = `${isOpen}:${folderPath}`;
+
+  // 逐次ローダー：1件ずつ順番にサムネイルを取得
+  const thumbnailUrls = useSequentialLoader(visiblePaths, THUMBNAIL_SIZE, resetKey);
+
+  // モーダルが開いたら画像一覧を取得
+  useEffect(() => {
+    if (!isOpen || !folderPath) return;
+
+    setImages([]);
+    setSelectedPath(null);
+    setError(null);
+    setLoading(true);
+
+    getImagesInFolder(folderPath, recursive)
+      .then((imgs) => {
+        setImages(imgs);
+      })
+      .catch((e) => {
+        console.error("画像一覧取得エラー:", e);
+        setError(`画像の読み込みに失敗しました: ${e}`);
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }, [isOpen, folderPath, recursive]);
+
+  const handleConfirm = () => {
+    if (selectedPath) {
+      onSelect(selectedPath);
+    }
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title="画像を選択"
+      width="xl"
+      footer={
+        <>
+          <Button variant="secondary" onClick={onClose}>
+            キャンセル
+          </Button>
+          <Button
+            variant="primary"
+            onClick={handleConfirm}
+            disabled={!selectedPath}
+          >
+            選択
+          </Button>
+        </>
+      }
+    >
+      {/* スクロールエリア（高さ固定） */}
+      <div className="h-96">
+        {loading ? (
+          <div className="h-full flex items-center justify-center">
+            <Spinner size="lg" text="画像を読み込み中..." />
+          </div>
+        ) : error ? (
+          <div className="h-full flex items-center justify-center">
+            <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+          </div>
+        ) : images.length === 0 ? (
+          <div className="h-full flex items-center justify-center">
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              このフォルダには画像がありません
+            </p>
+          </div>
+        ) : (
+          <div ref={scrollContainerRef} className="h-full overflow-y-auto">
+            <div
+              style={{
+                height: virtualizer.getTotalSize(),
+                position: "relative",
+              }}
+            >
+              {virtualizer.getVirtualItems().map((virtualRow) => {
+                const startIdx = virtualRow.index * COLS;
+                const rowImages = images.slice(startIdx, startIdx + COLS);
+                return (
+                  <div
+                    key={virtualRow.key}
+                    style={{
+                      position: "absolute",
+                      top: virtualRow.start,
+                      left: 0,
+                      right: 0,
+                      height: virtualRow.size,
+                    }}
+                    className="grid grid-cols-4 gap-2 px-1"
+                  >
+                    {rowImages.map((image) => (
+                      <ThumbnailCell
+                        key={image.path}
+                        image={image}
+                        isSelected={selectedPath === image.path}
+                        onSelect={setSelectedPath}
+                        url={thumbnailUrls[image.path]}
+                      />
+                    ))}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* 画像数表示 */}
+      {!loading && !error && images.length > 0 && (
+        <p className="mt-2 text-xs text-gray-500 dark:text-gray-400 text-right">
+          {images.length} 枚の画像
+        </p>
+      )}
+    </Modal>
+  );
+};

--- a/image-folder-viewer/src/components/common/Modal.tsx
+++ b/image-folder-viewer/src/components/common/Modal.tsx
@@ -19,13 +19,14 @@ interface ModalProps {
   // オプション
   closeOnOverlay?: boolean; // オーバーレイクリックで閉じるか（デフォルト: true）
   closeOnEscape?: boolean; // ESCキーで閉じるか（デフォルト: true）
-  width?: "sm" | "md" | "lg"; // モーダル幅（デフォルト: md）
+  width?: "sm" | "md" | "lg" | "xl"; // モーダル幅（デフォルト: md）
 }
 
 const widthClasses = {
   sm: "max-w-sm",
   md: "max-w-md",
   lg: "max-w-lg",
+  xl: "max-w-xl",
 };
 
 export const Modal = ({

--- a/image-folder-viewer/src/utils/thumbnailCache.ts
+++ b/image-folder-viewer/src/utils/thumbnailCache.ts
@@ -5,31 +5,115 @@ import { getThumbnail } from "../api/tauri";
 // DataURLメモリキャッシュ（アプリ起動中保持）
 const urlCache = new Map<string, string>();
 
-// 進行中リクエストのPromise（重複排除: 同じパス・サイズの同時リクエストを1つに集約）
-const pending = new Map<string, Promise<string>>();
+// セマフォ: 同時IPCリクエスト数を最大1に制限（CPU競合防止・スクロール操作性優先）
+const MAX_CONCURRENT = 1;
+let activeCount = 0;
+
+interface QueueEntry {
+  resolve: () => void; // activeCount++ してPromiseを解決する
+  cancelled: boolean;
+}
+const waitQueue: QueueEntry[] = [];
+
+function acquireSlot(): { promise: Promise<void>; cancelEntry: () => void } {
+  if (activeCount < MAX_CONCURRENT) {
+    activeCount++;
+    return { promise: Promise.resolve(), cancelEntry: () => {} };
+  }
+  let entry!: QueueEntry;
+  const promise = new Promise<void>((resolve) => {
+    entry = {
+      resolve: () => { activeCount++; resolve(); },
+      cancelled: false,
+    };
+    waitQueue.push(entry);
+  });
+  return { promise, cancelEntry: () => { entry.cancelled = true; } };
+}
+
+function releaseSlot(): void {
+  activeCount--;
+  // キャンセル済みエントリをスキップしてスロットを次の待機者に渡す
+  while (waitQueue.length > 0) {
+    const next = waitQueue.shift()!;
+    if (!next.cancelled) {
+      next.resolve(); // activeCount++ + Promise解決
+      return;
+    }
+    // キャンセル済み: スキップ（activeCount は増やさない = スロット解放済み状態を維持）
+  }
+}
+
+// 進行中リクエストの管理（重複排除 + キャンセル対応）
+interface PendingEntry {
+  promise: Promise<string>;
+  refCount: number;       // このキーを参照しているコンシューマー数
+  cancelEntry: (() => void) | null; // キュー待機中のみ有効、スロット取得後はnull
+  slotAcquired: boolean;  // スロットを取得してIPC発行済みかどうか
+}
+const pending = new Map<string, PendingEntry>();
 
 export function fetchThumbnail(imagePath: string, size: number): Promise<string> {
   const key = `${imagePath}:${size}`;
 
-  // メモリキャッシュヒット → 即時返却
+  // メモリキャッシュヒット → 即時返却（スロット消費なし）
   if (urlCache.has(key)) {
     return Promise.resolve(urlCache.get(key)!);
   }
 
-  // 進行中リクエストの重複排除
+  // 進行中リクエストの重複排除（スロット消費なし）
   if (pending.has(key)) {
-    return pending.get(key)!;
+    const entry = pending.get(key)!;
+    entry.refCount++;
+    return entry.promise;
   }
 
-  const promise = getThumbnail(imagePath, size)
+  const { promise: slotPromise, cancelEntry } = acquireSlot();
+  const pendingEntry: PendingEntry = {
+    promise: null!,
+    refCount: 1,
+    cancelEntry,
+    slotAcquired: false,
+  };
+
+  const promise = slotPromise
+    .then(() => {
+      pendingEntry.slotAcquired = true;
+      pendingEntry.cancelEntry = null; // IPC発行後はキャンセル不可
+      return getThumbnail(imagePath, size);
+    })
     .then((url) => {
       urlCache.set(key, url);
       return url;
     })
     .finally(() => {
+      if (pendingEntry.slotAcquired) {
+        releaseSlot();
+      }
       pending.delete(key);
     });
 
-  pending.set(key, promise);
+  pendingEntry.promise = promise;
+  pending.set(key, pendingEntry);
   return promise;
+}
+
+/**
+ * スクロールアウト等でサムネイルが不要になった際に呼ぶ。
+ * キュー待機中のリクエストをキャンセルしてスロットを解放する。
+ * IPC発行済み（スロット取得後）はキャンセル不可。
+ */
+export function cancelThumbnail(imagePath: string, size: number): void {
+  const key = `${imagePath}:${size}`;
+  const entry = pending.get(key);
+  if (!entry) return;
+
+  entry.refCount--;
+  if (entry.refCount <= 0 && entry.cancelEntry) {
+    // キュー待機中のエントリをキャンセル
+    entry.cancelEntry();
+    pending.delete(key);
+    // slotPromise は永遠に解決しないが、参照がなくなりGCされる
+    // releaseSlot 側でキャンセル済みエントリをスキップするため activeCount は正しく維持される
+  }
 }


### PR DESCRIPTION
## Summary

- `ImagePickerModal` を新規実装。仮想スクロール（@tanstack/react-virtual）対応のサムネイルグリッドで画像を選択できる
- `useSequentialLoader` フックで逐次フェッチ（1件ずつ処理）+ `requestIdleCallback` によりスクロール中のUI操作性を確保
- `thumbnailCache.ts` に `MAX_CONCURRENT=1` セマフォと `cancelThumbnail` を追加し、IPC の同時発行数を制限
- `Modal` コンポーネントに `width="xl"` を追加
- `CardAddModal` / `CardEditModal` の OS ダイアログ（`selectImageFile`）を `ImagePickerModal` に置き換え

## Known Issues / Related

- #37 スクロール中のフェッチによる UI 操作性の改善（スクロール中フラグ・バッチ更新）
- #38 画像のないフォルダを開くと操作不能になる（フォルダナビゲーション未実装）

## Test plan

- [ ] カード追加モーダルで「サムネイルを変更」→ ImagePickerModal が開くことを確認
- [ ] カード編集モーダルで同様に確認
- [ ] サムネイルが1枚ずつ順番に表示されることを確認
- [ ] 画像を選択して「選択」ボタンで閉じ、サムネイルに反映されることを確認
- [ ] 大量画像フォルダでスクロールし、操作が応答することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)