### PR TITLE
fix: macOS ZIPアーティファクトを画像一覧から除外 (#41)

### DIFF
--- a/image-folder-viewer/src-tauri/src/commands/images.rs
+++ b/image-folder-viewer/src-tauri/src/commands/images.rs
@@ -195,6 +195,12 @@ fn is_image_file(path: &Path) -> bool {
     if !path.is_file() {
         return false;
     }
+    // macOS AppleDouble リソースフォークファイル（._xxx）を除外
+    if let Some(name) = path.file_name() {
+        if name.to_string_lossy().starts_with("._") {
+            return false;
+        }
+    }
     if let Some(ext) = path.extension() {
         let ext_lower = ext.to_string_lossy().to_lowercase();
         return IMAGE_EXTENSIONS.contains(&ext_lower.as_str());
@@ -216,7 +222,14 @@ fn collect_images(dir: &Path, recursive: bool) -> Result<Vec<PathBuf>, String> {
         if is_image_file(&path) {
             result.push(path);
         } else if recursive && path.is_dir() {
-            dirs.push(path);
+            // macOS アーティファクトディレクトリ（__MACOSX）を除外
+            let skip = path
+                .file_name()
+                .map(|n| n == "__MACOSX")
+                .unwrap_or(false);
+            if !skip {
+                dirs.push(path);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

macOS で作成された ZIP を Linux で展開した際に生成される `__MACOSX/` ディレクトリと `._*` ファイル（AppleDouble リソースフォーク）が画像一覧に混入し、asset プロトコルで 403 エラーになるバグを修正。

- `is_image_file`: ファイル名が `._` で始まるファイルを除外
- `collect_images`: `__MACOSX` ディレクトリを再帰走査から除外

## Test plan

- [ ] macOS ZIP 由来の `__MACOSX/` を含むフォルダを ImagePickerModal で開き、`._*` ファイルが一覧に表示されないことを確認
- [ ] 同フォルダをカードに設定してビューアを開き、正常な画像のみナビゲートできることを確認
- [ ] `__MACOSX` を含まない通常フォルダで画像一覧が正常に表示されることを確認

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)