### PR TITLE
fix: useSequentialLoader の loadingRef リセットタイミングバグ修正 (#43)

### DIFF
--- a/image-folder-viewer/src/components/common/ImagePickerModal.tsx
+++ b/image-folder-viewer/src/components/common/ImagePickerModal.tsx
@@ -43,7 +43,9 @@ function useSequentialLoader(
   visibleRef.current = visiblePaths;
 
   // resetKey 変更時（フォルダ変更・モーダル再オープン）に状態リセット
+  // loadingRef もリセットすることで、前セッションのfetch待ち中でも新セッションが即開始できる
   useEffect(() => {
+    loadingRef.current = false;
     processedRef.current = new Set();
     setUrls({});
   }, [resetKey]);

--- a/image-folder-viewer/src/components/common/ImagePickerModal.tsx
+++ b/image-folder-viewer/src/components/common/ImagePickerModal.tsx
@@ -69,10 +69,11 @@ function useSequentialLoader(
         setUrls((prev) => ({ ...prev, [path]: null }));
       }
 
-      loadingRef.current = false;
-
       // ブラウザのアイドル時間に次を処理（スクロール中は自動的に停止）
       // timeout: スクロールし続けても最大 200ms 以内には実行する（thumbnails の表示遅延上限）
+      // NOTE: idle 待機の前に false にすると setUrls() による再レンダーで useEffect が再発火し
+      //       loadingRef.current === false のまま次の processNext() が起動してしまうため、
+      //       必ず待機完了後に false にすること。
       await new Promise<void>((r) => {
         if (typeof requestIdleCallback !== "undefined") {
           requestIdleCallback(() => r(), { timeout: 200 });
@@ -80,6 +81,7 @@ function useSequentialLoader(
           setTimeout(r, 16);
         }
       });
+      loadingRef.current = false;
       processNext();
     };
 


### PR DESCRIPTION
## 概要

`useSequentialLoader` フックで `loadingRef.current = false` を `requestIdleCallback` の前にセットしていたため、idle 待機中に `useEffect` が再発火すると次の `processNext()` がすぐに起動してしまうバグを修正。

## 変更内容

`loadingRef.current = false` を idle 待機の**後**に移動。

```typescript
// 修正前
loadingRef.current = false;
await new Promise<void>((r) => { requestIdleCallback(...) });
processNext();

// 修正後
await new Promise<void>((r) => { requestIdleCallback(...) });
loadingRef.current = false;
processNext();
```

## 修正の理由

`setUrls()` → React 再レンダー → `visiblePaths` の参照変更 → `useEffect([visiblePaths,...])` 再発火 → `loadingRef.current === false` のためガードを通過 → 複数の `processNext()` が並走し `requestIdleCallback` の yield がスキップされる。

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)